### PR TITLE
feat: scaffold ERP frontend and backend foundations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Variables compartidas
+DATABASE_URL=
+PIPEDRIVE_BASE_URL=https://api.pipedrive.com/v1
+PIPEDRIVE_API_TOKEN=
+PORT=4000

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+node_modules
+npm-debug.log*
+.DS_Store
+.env
+.env.local
+.env.*
+!.env.example
+.idea
+.vscode
+coverage
+/dist
+/frontend/dist
+/backend/dist

--- a/README.md
+++ b/README.md
@@ -47,3 +47,51 @@ ERP interno colaborativo para planificar, visualizar y gestionar formaciones pro
 - Definir primer esquema Prisma y migración inicial que refleje las tablas descritas.
 
 Este documento servirá como referencia viva para las decisiones técnicas y planificación del ERP.
+
+## Estructura del repositorio
+
+```
+.
+├── backend/        # API Express + Prisma conectada a Neon
+├── frontend/       # Aplicación React (Vite + TypeScript + Bootstrap)
+├── .env.example    # Plantilla de variables de entorno
+├── package.json    # Configuración de workspaces y scripts compartidos
+└── README.md
+```
+
+## Cómo empezar
+
+1. **Instalar dependencias**
+
+   ```bash
+   npm install
+   npm --workspace backend install
+   npm --workspace frontend install
+   ```
+
+2. **Configurar variables de entorno**
+
+   Copia `.env.example` a `.env` y rellena los valores proporcionados por Netlify/Neon.
+
+3. **Lanzar los entornos de desarrollo**
+
+   ```bash
+   npm run dev:backend   # http://localhost:4000
+   npm run dev:frontend  # http://localhost:5173
+   ```
+
+## Convenciones de diseño UI
+
+- Tipografía principal: Poppins (variantes 300/400/600/700).
+- Colores corporativos suavizados:
+  - Rojo principal: `#e8474d`
+  - Gris oscuro: `#2a2a2a`
+  - Gris medio: `#565656`
+  - Gris claro: `#f2f2f2`
+- Componentes clave personalizados: botones, navegación superior, tablas y modales Bootstrap adaptados a la línea visual.
+
+## Estado actual
+
+- **Frontend**: layout inicial con cabecera corporativa, pestañas de navegación y módulo de Presupuestos con modal de importación, tabla responsive y modal de detalle.
+- **Backend**: servidor Express con endpoint `POST /api/deals/import` preparado para sincronizar un presupuesto desde Pipedrive, normalizar datos y guardarlos en Neon mediante Prisma.
+- **Base de datos**: esquema Prisma que refleja las tablas y relaciones solicitadas (organizaciones, personas, deals, notas, documentos, sesiones, formadores y unidades móviles).

--- a/backend/.eslintrc.cjs
+++ b/backend/.eslintrc.cjs
@@ -1,0 +1,17 @@
+module.exports = {
+  root: true,
+  env: {
+    es2020: true,
+    node: true
+  },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module'
+  },
+  plugins: ['@typescript-eslint'],
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
+  rules: {
+    '@typescript-eslint/consistent-type-imports': ['error', { prefer: 'type-imports' }]
+  }
+};

--- a/backend/.prettierrc
+++ b/backend/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "tabWidth": 2,
+  "printWidth": 100
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "backend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "ts-node-dev --respawn --transpile-only src/server.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/server.js",
+    "lint": "eslint \"src/**/*.ts\" --max-warnings=0",
+    "prisma:migrate": "prisma migrate dev",
+    "prisma:generate": "prisma generate"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.18.0",
+    "axios": "^1.7.7",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "helmet": "^7.1.0",
+    "pino": "^9.3.2",
+    "pino-http": "^10.3.0",
+    "pino-pretty": "^11.2.2",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "@types/node": "^22.5.5",
+    "@typescript-eslint/eslint-plugin": "^7.17.0",
+    "@typescript-eslint/parser": "^7.17.0",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "prisma": "^5.18.0",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.5.4"
+  }
+}

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,0 +1,140 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model Organization {
+  id        Int       @id
+  name      String
+  cif       String?   @db.VarChar(255)
+  phone     String?   @db.VarChar(255)
+  address   String?   @db.Text
+  persons   Person[]
+  deals     Deal[]
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+}
+
+model Person {
+  id             Int             @id
+  organizationId Int
+  organization   Organization    @relation(fields: [organizationId], references: [id])
+  firstName      String?         @db.VarChar(255)
+  lastName       String?         @db.VarChar(255)
+  email          String?         @db.VarChar(255)
+  phone          String?         @db.VarChar(255)
+  participants   DealParticipant[]
+  createdAt      DateTime        @default(now())
+  updatedAt      DateTime        @updatedAt
+}
+
+model Deal {
+  id              Int               @id
+  organizationId  Int
+  organization    Organization      @relation(fields: [organizationId], references: [id])
+  title           String
+  trainingType    String?           @db.VarChar(255)
+  hours           Int?
+  direction       String?           @db.VarChar(255)
+  sede            String?           @db.VarChar(255)
+  caes            String?           @db.VarChar(255)
+  fundae          String?           @db.VarChar(255)
+  hotelNight      String?           @db.VarChar(255)
+  alumnos         Int?              @default(0)
+  training        Json?
+  prodExtra       Json?
+  documentsNum    Int?              @default(0)
+  documentsIds    String?           @db.Text
+  sessionsNum     Int?              @default(0)
+  sessionsIds     String?           @db.Text
+  notesNum        Int?              @default(0)
+  createdAt       DateTime          @default(now())
+  updatedAt       DateTime          @updatedAt
+  notes           Note[]
+  documents       Document[]
+  sessions        Session[]
+  participants    DealParticipant[]
+}
+
+model Note {
+  id        Int      @id
+  dealId    Int
+  deal      Deal     @relation(fields: [dealId], references: [id])
+  comment   String
+  createdAt DateTime @default(now())
+}
+
+model Document {
+  id        Int      @id
+  dealId    Int
+  deal      Deal     @relation(fields: [dealId], references: [id])
+  title     String
+  url       String?  @db.Text
+  createdAt DateTime @default(now())
+}
+
+model Session {
+  id                String             @id
+  dealId            Int
+  deal              Deal               @relation(fields: [dealId], references: [id])
+  status            String?            @db.VarChar(255)
+  dateStart         DateTime?
+  dateEnd           DateTime?
+  sede              String?            @db.VarChar(255)
+  address           String?            @db.Text
+  firemanId         String?            @db.VarChar(255)
+  vehicleId         String?            @db.VarChar(255)
+  comment           String?            @db.Text
+  trainers          SessionTrainer[]
+  mobileUnits       SessionMobileUnit[]
+  createdAt         DateTime           @default(now())
+  updatedAt         DateTime           @updatedAt
+}
+
+model Trainer {
+  id        String            @id
+  name      String
+  sessions  SessionTrainer[]
+  createdAt DateTime          @default(now())
+  updatedAt DateTime          @updatedAt
+}
+
+model MobileUnit {
+  id        String              @id
+  name      String
+  sessions  SessionMobileUnit[]
+  createdAt DateTime            @default(now())
+  updatedAt DateTime            @updatedAt
+}
+
+model SessionTrainer {
+  sessionId String
+  trainerId String
+  session   Session @relation(fields: [sessionId], references: [id])
+  trainer   Trainer @relation(fields: [trainerId], references: [id])
+
+  @@id([sessionId, trainerId])
+}
+
+model SessionMobileUnit {
+  sessionId String
+  mobileId  String
+  session   Session    @relation(fields: [sessionId], references: [id])
+  mobile    MobileUnit @relation(fields: [mobileId], references: [id])
+
+  @@id([sessionId, mobileId])
+}
+
+model DealParticipant {
+  dealId   Int
+  personId Int
+  role     String? @db.VarChar(255)
+  deal     Deal    @relation(fields: [dealId], references: [id])
+  person   Person  @relation(fields: [personId], references: [id])
+
+  @@id([dealId, personId])
+}

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -1,0 +1,23 @@
+import { config } from 'dotenv';
+import { z } from 'zod';
+
+config();
+
+const envSchema = z.object({
+  NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
+  PORT: z.coerce.number().default(4000),
+  DATABASE_URL: z.string().min(1, 'DATABASE_URL es obligatorio'),
+  PIPEDRIVE_BASE_URL: z.string().url(),
+  PIPEDRIVE_API_TOKEN: z.string().min(1, 'PIPEDRIVE_API_TOKEN es obligatorio')
+});
+
+type EnvSchema = z.infer<typeof envSchema>;
+
+const parsed = envSchema.safeParse(process.env);
+
+if (!parsed.success) {
+  console.error('❌ Configuración de entorno inválida', parsed.error.flatten().fieldErrors);
+  throw new Error('Variables de entorno inválidas');
+}
+
+export const env: EnvSchema = parsed.data;

--- a/backend/src/routes/deals.ts
+++ b/backend/src/routes/deals.ts
@@ -1,0 +1,24 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { importDealFromPipedrive } from '../services/importDeal';
+
+const router = Router();
+
+const importSchema = z.object({
+  federalNumber: z.string().min(3, 'El número federal debe tener al menos 3 caracteres')
+});
+
+router.post('/import', async (req, res, next) => {
+  try {
+    const payload = importSchema.parse(req.body);
+    const deal = await importDealFromPipedrive(payload.federalNumber);
+    res.json(deal);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({ message: 'Datos inválidos', issues: error.errors });
+    }
+    return next(error);
+  }
+});
+
+export const dealsRouter = router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,0 +1,42 @@
+import express from 'express';
+import cors from 'cors';
+import helmet from 'helmet';
+import pino from 'pino';
+import pinoHttp from 'pino-http';
+import { env } from './config/env';
+import { dealsRouter } from './routes/deals';
+
+const logger = pino({
+  transport: env.NODE_ENV === 'development' ? { target: 'pino-pretty' } : undefined,
+  level: env.NODE_ENV === 'development' ? 'debug' : 'info'
+});
+
+const app = express();
+app.use(express.json());
+app.use(cors({ origin: true, credentials: true }));
+app.use(helmet());
+app.use(
+  pinoHttp({
+    logger,
+    serializers: {
+      req(request) {
+        return { method: request.method, url: request.url };
+      }
+    }
+  })
+);
+
+app.get('/health', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.use('/api/deals', dealsRouter);
+
+app.use((err: unknown, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+  logger.error(err, 'Unhandled error');
+  res.status(500).json({ message: 'Error interno del servidor' });
+});
+
+app.listen(env.PORT, () => {
+  logger.info(`Servidor escuchando en http://localhost:${env.PORT}`);
+});

--- a/backend/src/services/importDeal.ts
+++ b/backend/src/services/importDeal.ts
@@ -1,0 +1,298 @@
+import type { DealSummary } from '../types/deal';
+import { pipedriveClient } from './pipedriveClient';
+import { prisma } from './prisma';
+
+const DEAL_CUSTOM_FIELDS = {
+  hours: '38f11c8876ecde803a027fbf3c9041fda2ae7eb7',
+  direction: '8b2a7570f5ba8aa4754f061cd9dc92fd778376a7',
+  sede: '676d6bd51e52999c582c01f67c99a35ed30bf6ae',
+  caes: 'e1971bf3a21d48737b682bf8d864ddc5eb15a351',
+  fundae: '245d60d4d18aec40ba888998ef92e5d00e494583',
+  hotelNight: 'c3a6daf8eb5b4e59c3c07cda8e01f43439101269',
+  pipeline: 'pipeline_id'
+} as const;
+
+const ORGANIZATION_CUSTOM_FIELDS = {
+  cif: '6d39d015a33921753410c1bab0b067ca93b8cf2c',
+  phone: 'b4379db06dfbe0758d84c2c2dd45ef04fa093b6d'
+} as const;
+
+type DealResponse = {
+  id: number;
+  title: string;
+  org_id?: { value: number; name: string } | number;
+  person_id?: { value: number } | number;
+  [key: string]: unknown;
+};
+
+type ProductResponse = {
+  product_id: number;
+  name: string;
+  code?: string;
+  quantity?: number | string;
+};
+
+type OrganizationResponse = {
+  id: number;
+  name: string;
+  address?: string;
+  [key: string]: unknown;
+};
+
+type PersonResponse = {
+  id: number;
+  first_name?: string;
+  last_name?: string;
+  email?: Array<{ value: string; primary?: boolean }> | string;
+  phone?: Array<{ value: string; primary?: boolean }> | string;
+};
+
+type NoteResponse = {
+  id: number;
+  content: string;
+};
+
+type FileResponse = {
+  id: number;
+  name: string;
+  file_url?: string;
+};
+
+function extractField<T>(entity: Record<string, unknown> | null | undefined, key: string): T | null {
+  if (!entity) {
+    return null;
+  }
+
+  const value = entity[key];
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value === 'object' && 'value' in (value as Record<string, unknown>)) {
+    return ((value as Record<string, unknown>).value ?? null) as T | null;
+  }
+  return value as T;
+}
+
+function ensureArray<T>(value: T | T[] | undefined | null): T[] {
+  if (!value) {
+    return [];
+  }
+  return Array.isArray(value) ? value : [value];
+}
+
+function extractPrimaryFromField(field: PersonResponse['email']): string | null {
+  if (!field) {
+    return null;
+  }
+
+  if (typeof field === 'string') {
+    return field;
+  }
+
+  const values = field as Array<{ value: string; primary?: boolean }>;
+  const primary = values.find((entry) => entry.primary);
+  return (primary ?? values[0])?.value ?? null;
+}
+
+function parseQuantity(quantity: ProductResponse['quantity']): number {
+  if (quantity === null || quantity === undefined) {
+    return 0;
+  }
+
+  if (typeof quantity === 'number') {
+    return quantity;
+  }
+
+  const parsed = parseInt(quantity, 10);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+export async function importDealFromPipedrive(federalNumber: string): Promise<DealSummary> {
+  const dealResponse = await pipedriveClient.get<{ data: (DealResponse & { products?: ProductResponse[] }) | null }>(
+    `/deals/${encodeURIComponent(federalNumber)}`,
+    { params: { include_products: 1 } }
+  );
+
+  const dealData = dealResponse.data?.data;
+
+  if (!dealData) {
+    throw new Error('No se ha encontrado el presupuesto solicitado en Pipedrive.');
+  }
+
+  const orgRaw = dealData.org_id;
+  const orgId = typeof orgRaw === 'object' ? orgRaw?.value : orgRaw;
+
+  if (!orgId) {
+    throw new Error('El presupuesto no tiene una organización asociada.');
+  }
+
+  const personId = dealData.person_id
+    ? typeof dealData.person_id === 'object'
+      ? dealData.person_id.value
+      : dealData.person_id
+    : null;
+
+  const [organizationResponse, personResponse, notesResponse, filesResponse] = await Promise.all([
+    pipedriveClient.get<{ data: OrganizationResponse | null }>(`/organizations/${orgId}`),
+    personId
+      ? pipedriveClient.get<{ data: PersonResponse | null }>(`/persons/${personId}`)
+      : Promise.resolve<{ data: PersonResponse | null }>({ data: null }),
+    pipedriveClient.get<{ data: NoteResponse[] | null }>(`/deals/${dealData.id}/notes`),
+    pipedriveClient.get<{ data: FileResponse[] | null }>(`/deals/${dealData.id}/files`)
+  ]);
+
+  const organizationData = organizationResponse.data ?? null;
+  const primaryPerson = personResponse.data ?? null;
+  const notes = notesResponse.data ?? [];
+  const files = filesResponse.data ?? [];
+
+  const products = ensureArray((dealData as DealResponse & { products?: ProductResponse[] }).products);
+  const trainingProducts = products.filter((product) => product.code?.toLowerCase().startsWith('form-'));
+  const extraProducts = products.filter((product) => !(product.code?.toLowerCase().startsWith('form-') ?? false));
+
+  const sedeValue = extractField<string>(dealData, DEAL_CUSTOM_FIELDS.sede) ?? '';
+  const trainingType = extractField<string>(dealData, DEAL_CUSTOM_FIELDS.pipeline);
+  const hoursValue = extractField<number | string>(dealData, DEAL_CUSTOM_FIELDS.hours);
+  const parsedHours =
+    hoursValue === null || hoursValue === undefined
+      ? null
+      : typeof hoursValue === 'number'
+      ? hoursValue
+      : Number.isNaN(parseInt(hoursValue, 10))
+      ? null
+      : parseInt(hoursValue, 10);
+  const sessionsCount = trainingProducts.reduce((total, product) => total + parseQuantity(product.quantity), 0);
+
+  const dealSummary: DealSummary = {
+    dealId: dealData.id,
+    title: dealData.title,
+    clientName: organizationData?.name ?? 'Organización sin nombre',
+    sede: sedeValue,
+    trainingNames: trainingProducts.map((product) => product.name).filter(Boolean),
+    trainingType,
+    hours: parsedHours,
+    caes: extractField<string>(dealData, DEAL_CUSTOM_FIELDS.caes),
+    fundae: extractField<string>(dealData, DEAL_CUSTOM_FIELDS.fundae),
+    hotelNight: extractField<string>(dealData, DEAL_CUSTOM_FIELDS.hotelNight),
+    notes: notes.map((note) => note.content),
+    documents: files.map((file) => file.name)
+  };
+
+  await prisma.$transaction(async (tx) => {
+    await tx.organization.upsert({
+      where: { id: orgId },
+      create: {
+        id: orgId,
+        name: organizationData?.name ?? 'Organización sin nombre',
+        cif: extractField<string>(organizationData, ORGANIZATION_CUSTOM_FIELDS.cif),
+        phone: extractField<string>(organizationData, ORGANIZATION_CUSTOM_FIELDS.phone),
+        address: organizationData?.address ?? null
+      },
+      update: {
+        name: organizationData?.name ?? 'Organización sin nombre',
+        cif: extractField<string>(organizationData, ORGANIZATION_CUSTOM_FIELDS.cif),
+        phone: extractField<string>(organizationData, ORGANIZATION_CUSTOM_FIELDS.phone),
+        address: organizationData?.address ?? null
+      }
+    });
+
+    if (primaryPerson) {
+      await tx.person.upsert({
+        where: { id: primaryPerson.id },
+        create: {
+          id: primaryPerson.id,
+          organizationId: orgId,
+          firstName: primaryPerson.first_name ?? null,
+          lastName: primaryPerson.last_name ?? null,
+          email: extractPrimaryFromField(primaryPerson.email ?? null),
+          phone: extractPrimaryFromField(primaryPerson.phone ?? null)
+        },
+        update: {
+          organizationId: orgId,
+          firstName: primaryPerson.first_name ?? null,
+          lastName: primaryPerson.last_name ?? null,
+          email: extractPrimaryFromField(primaryPerson.email ?? null),
+          phone: extractPrimaryFromField(primaryPerson.phone ?? null)
+        }
+      });
+
+      await tx.dealParticipant.upsert({
+        where: { dealId_personId: { dealId: dealData.id, personId: primaryPerson.id } },
+        create: {
+          dealId: dealData.id,
+          personId: primaryPerson.id,
+          role: 'Responsable'
+        },
+        update: {
+          role: 'Responsable'
+        }
+      });
+    }
+
+    await tx.deal.upsert({
+      where: { id: dealData.id },
+      create: {
+        id: dealData.id,
+        organizationId: orgId,
+        title: dealData.title,
+        trainingType,
+        hours: parsedHours,
+        direction: extractField<string>(dealData, DEAL_CUSTOM_FIELDS.direction),
+        sede: sedeValue,
+        caes: dealSummary.caes,
+        fundae: dealSummary.fundae,
+        hotelNight: dealSummary.hotelNight,
+        alumnos: 0,
+        training: trainingProducts,
+        prodExtra: extraProducts,
+        documentsNum: files.length,
+        documentsIds: files.map((file) => file.id).join(',') || null,
+        sessionsNum: sessionsCount,
+        sessionsIds: null,
+        notesNum: notes.length
+      },
+      update: {
+        organizationId: orgId,
+        title: dealData.title,
+        trainingType,
+        hours: parsedHours,
+        direction: extractField<string>(dealData, DEAL_CUSTOM_FIELDS.direction),
+        sede: sedeValue,
+        caes: dealSummary.caes,
+        fundae: dealSummary.fundae,
+        hotelNight: dealSummary.hotelNight,
+        training: trainingProducts,
+        prodExtra: extraProducts,
+        documentsNum: files.length,
+        documentsIds: files.map((file) => file.id).join(',') || null,
+        sessionsNum: sessionsCount,
+        notesNum: notes.length
+      }
+    });
+
+    await tx.note.deleteMany({ where: { dealId: dealData.id } });
+    if (notes.length) {
+      await tx.note.createMany({
+        data: notes.map((note) => ({
+          id: note.id,
+          dealId: dealData.id,
+          comment: note.content
+        }))
+      });
+    }
+
+    await tx.document.deleteMany({ where: { dealId: dealData.id } });
+    if (files.length) {
+      await tx.document.createMany({
+        data: files.map((file) => ({
+          id: file.id,
+          dealId: dealData.id,
+          title: file.name,
+          url: file.file_url ?? null
+        }))
+      });
+    }
+  });
+
+  return dealSummary;
+}

--- a/backend/src/services/pipedriveClient.ts
+++ b/backend/src/services/pipedriveClient.ts
@@ -1,0 +1,9 @@
+import axios from 'axios';
+import { env } from '../config/env';
+
+export const pipedriveClient = axios.create({
+  baseURL: env.PIPEDRIVE_BASE_URL,
+  params: {
+    api_token: env.PIPEDRIVE_API_TOKEN
+  }
+});

--- a/backend/src/services/prisma.ts
+++ b/backend/src/services/prisma.ts
@@ -1,0 +1,3 @@
+import { PrismaClient } from '@prisma/client';
+
+export const prisma = new PrismaClient();

--- a/backend/src/types/deal.ts
+++ b/backend/src/types/deal.ts
@@ -1,0 +1,14 @@
+export interface DealSummary {
+  dealId: number;
+  title: string;
+  clientName: string;
+  sede: string;
+  trainingNames: string[];
+  trainingType?: string | null;
+  hours?: number | null;
+  caes?: string | null;
+  fundae?: string | null;
+  hotelNight?: string | null;
+  notes?: string[];
+  documents?: string[];
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -1,0 +1,22 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2020: true
+  },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module'
+  },
+  plugins: ['@typescript-eslint', 'react-hooks'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:react-hooks/recommended',
+    'prettier'
+  ],
+  rules: {
+    '@typescript-eslint/explicit-module-boundary-types': 'off'
+  }
+};

--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "trailingComma": "none",
+  "tabWidth": 2,
+  "printWidth": 100
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GEP Group – Planificación</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint \"src/**/*.{ts,tsx}\" --max-warnings=0"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.51.15",
+    "axios": "^1.7.7",
+    "bootstrap": "^5.3.3",
+    "react-bootstrap": "^2.10.4",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.5",
+    "@types/react-dom": "^18.3.0",
+    "@typescript-eslint/eslint-plugin": "^7.17.0",
+    "@typescript-eslint/parser": "^7.17.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "postcss": "^8.4.40",
+    "prettier": "^3.3.3",
+    "typescript": "^5.5.4",
+    "vite": "^5.4.3"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,139 @@
+import { useMemo, useState } from 'react';
+import { Container, Nav, Navbar, Button, Alert, Spinner } from 'react-bootstrap';
+import { useMutation } from '@tanstack/react-query';
+import { BudgetImportModal } from './features/presupuestos/BudgetImportModal';
+import { BudgetTable } from './features/presupuestos/BudgetTable';
+import { BudgetDetailModal } from './features/presupuestos/BudgetDetailModal';
+import { importDeal } from './features/presupuestos/api';
+import type { DealSummary } from './types/deal';
+import logo from './assets/logo.svg';
+
+const NAVIGATION_ITEMS = ['Presupuestos', 'Calendario', 'Recursos'];
+
+export default function App() {
+  const [showImportModal, setShowImportModal] = useState(false);
+  const [budgets, setBudgets] = useState<DealSummary[]>([]);
+  const [selectedBudget, setSelectedBudget] = useState<DealSummary | null>(null);
+  const [activeTab, setActiveTab] = useState('Presupuestos');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const importMutation = useMutation({
+    mutationFn: importDeal,
+    onSuccess: (budget) => {
+      setBudgets((previous) => {
+        const filtered = previous.filter((item) => item.dealId !== budget.dealId);
+        return [budget, ...filtered];
+      });
+      setSelectedBudget(budget);
+      setErrorMessage(null);
+      setShowImportModal(false);
+    },
+    onError: (error: unknown) => {
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : 'No se ha podido importar el presupuesto. Inténtalo de nuevo más tarde.'
+      );
+    }
+  });
+
+  const isBudgetsView = activeTab === 'Presupuestos';
+  const secondaryTabs = useMemo(() => NAVIGATION_ITEMS.filter((item) => item !== 'Presupuestos'), []);
+
+  return (
+    <div className="min-vh-100 d-flex flex-column">
+      <Navbar bg="white" expand="lg" className="shadow-sm py-3">
+        <Container fluid="xl" className="d-flex align-items-center gap-4">
+          <Navbar.Brand href="#" className="d-flex align-items-center gap-3">
+            <img src={logo} height={32} alt="GEP Group" />
+            <div>
+              <span className="d-block fw-semibold text-uppercase small text-muted">GEP Group</span>
+              <span className="d-block fw-bold" style={{ color: 'var(--color-red)' }}>
+                Planificación de formaciones
+              </span>
+            </div>
+          </Navbar.Brand>
+          <Nav className="ms-auto gap-3">
+            {NAVIGATION_ITEMS.map((item) => (
+              <Nav.Item key={item}>
+                <Nav.Link
+                  active={activeTab === item}
+                  onClick={() => setActiveTab(item)}
+                  className="text-uppercase"
+                >
+                  {item}
+                </Nav.Link>
+              </Nav.Item>
+            ))}
+          </Nav>
+        </Container>
+      </Navbar>
+
+      <main className="flex-grow-1 py-5">
+        <Container fluid="xl">
+          {isBudgetsView ? (
+            <div className="d-grid gap-4">
+              <section className="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3">
+                <div>
+                  <h1 className="h3 fw-bold mb-1">Presupuestos</h1>
+                  <p className="text-muted mb-0">
+                    Importa presupuestos desde Pipedrive y centraliza toda la información clave para planificar.
+                  </p>
+                </div>
+                <div className="d-flex align-items-center gap-3">
+                  {importMutation.isPending && <Spinner animation="border" role="status" size="sm" />}
+                  <Button size="lg" onClick={() => setShowImportModal(true)}>
+                    Importar presupuesto
+                  </Button>
+                </div>
+              </section>
+
+              {errorMessage && (
+                <Alert
+                  variant="danger"
+                  className="rounded-4 shadow-sm"
+                  onClose={() => setErrorMessage(null)}
+                  dismissible
+                >
+                  {errorMessage}
+                </Alert>
+              )}
+
+              <BudgetTable budgets={budgets} onSelect={setSelectedBudget} />
+            </div>
+          ) : (
+            <div className="bg-white rounded-4 shadow-sm p-5 text-center text-muted">
+              <h2 className="h4 fw-semibold mb-2">{activeTab}</h2>
+              <p className="mb-0">
+                Esta sección estará disponible próximamente. Mientras tanto, puedes seguir trabajando en la pestaña
+                de Presupuestos.
+              </p>
+              <div className="d-flex justify-content-center gap-2 mt-4">
+                {secondaryTabs.map((tab) => (
+                  <Button key={tab} variant="outline-secondary" size="sm" disabled>
+                    {tab}
+                  </Button>
+                ))}
+              </div>
+            </div>
+          )}
+        </Container>
+      </main>
+
+      <footer className="py-4 bg-white mt-auto border-top">
+        <Container fluid="xl" className="text-muted small d-flex justify-content-between align-items-center">
+          <span>© {new Date().getFullYear()} GEP Group</span>
+          <span>ERP colaborativo para planificación de formaciones</span>
+        </Container>
+      </footer>
+
+      <BudgetImportModal
+        show={showImportModal}
+        isLoading={importMutation.isPending}
+        onClose={() => setShowImportModal(false)}
+        onSubmit={(federalNumber) => importMutation.mutate({ federalNumber })}
+      />
+      <BudgetDetailModal budget={selectedBudget} onClose={() => setSelectedBudget(null)} />
+    </div>
+  );
+}

--- a/frontend/src/assets/logo.svg
+++ b/frontend/src/assets/logo.svg
@@ -1,0 +1,4 @@
+<svg width="120" height="32" viewBox="0 0 120 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="120" height="32" rx="6" fill="#242424" />
+  <text x="12" y="21" fill="#ffffff" font-family="Poppins, sans-serif" font-size="14" font-weight="600">GEP Group</text>
+</svg>

--- a/frontend/src/features/presupuestos/BudgetDetailModal.tsx
+++ b/frontend/src/features/presupuestos/BudgetDetailModal.tsx
@@ -1,0 +1,87 @@
+import { Modal, Badge } from 'react-bootstrap';
+import type { DealSummary } from '../../types/deal';
+
+interface BudgetDetailModalProps {
+  budget: DealSummary | null;
+  onClose: () => void;
+}
+
+export function BudgetDetailModal({ budget, onClose }: BudgetDetailModalProps) {
+  return (
+    <Modal show={!!budget} onHide={onClose} centered size="lg">
+      <Modal.Header closeButton className="border-0 pb-0">
+        <Modal.Title className="fw-semibold text-uppercase">
+          {budget ? `Presupuesto #${budget.dealId}` : 'Presupuesto'}
+        </Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        {budget ? (
+          <div className="d-grid gap-4">
+            <section>
+              <h6 className="text-uppercase text-muted fw-semibold small">Resumen</h6>
+              <p className="mb-1 fw-semibold">{budget.title}</p>
+              <p className="mb-0 text-muted">{budget.clientName}</p>
+            </section>
+            <section>
+              <h6 className="text-uppercase text-muted fw-semibold small">Sede</h6>
+              <p className="mb-0">{budget.sede}</p>
+            </section>
+            <section>
+              <h6 className="text-uppercase text-muted fw-semibold small">Formación</h6>
+              {budget.trainingNames.length ? (
+                <div className="d-flex flex-wrap gap-2">
+                  {budget.trainingNames.map((training) => (
+                    <Badge bg="light" text="dark" key={training} className="px-3 py-2 rounded-pill">
+                      {training}
+                    </Badge>
+                  ))}
+                </div>
+              ) : (
+                <p className="mb-0 text-muted">Sin productos formativos vinculados.</p>
+              )}
+            </section>
+            <section>
+              <h6 className="text-uppercase text-muted fw-semibold small">Detalles operativos</h6>
+              <dl className="row mb-0 small">
+                <dt className="col-sm-4 text-muted">Tipo de formación</dt>
+                <dd className="col-sm-8">{budget.trainingType ?? 'Pendiente de sincronizar'}</dd>
+                <dt className="col-sm-4 text-muted">Horas</dt>
+                <dd className="col-sm-8">{budget.hours ?? '—'}</dd>
+                <dt className="col-sm-4 text-muted">CAES</dt>
+                <dd className="col-sm-8">{budget.caes ?? '—'}</dd>
+                <dt className="col-sm-4 text-muted">FUNDAE</dt>
+                <dd className="col-sm-8">{budget.fundae ?? '—'}</dd>
+                <dt className="col-sm-4 text-muted">Hotel y pernocta</dt>
+                <dd className="col-sm-8">{budget.hotelNight ?? '—'}</dd>
+              </dl>
+            </section>
+            <section>
+              <h6 className="text-uppercase text-muted fw-semibold small">Documentos</h6>
+              {budget.documents && budget.documents.length ? (
+                <ul className="mb-0 small">
+                  {budget.documents.map((doc) => (
+                    <li key={doc}>{doc}</li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="mb-0 text-muted">Aún no hay documentos asociados.</p>
+              )}
+            </section>
+            <section>
+              <h6 className="text-uppercase text-muted fw-semibold small">Notas</h6>
+              {budget.notes && budget.notes.length ? (
+                <ul className="mb-0 small">
+                  {budget.notes.map((note, index) => (
+                    <li key={`${note}-${index}`}>{note}</li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="mb-0 text-muted">Aún no hay notas asociadas.</p>
+              )}
+            </section>
+          </div>
+        ) : null}
+      </Modal.Body>
+    </Modal>
+  );
+}

--- a/frontend/src/features/presupuestos/BudgetImportModal.tsx
+++ b/frontend/src/features/presupuestos/BudgetImportModal.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useRef, useState } from 'react';
+import { Modal, Button, Form } from 'react-bootstrap';
+
+interface BudgetImportModalProps {
+  show: boolean;
+  isLoading: boolean;
+  onClose: () => void;
+  onSubmit: (federalNumber: string) => void;
+}
+
+export function BudgetImportModal({ show, isLoading, onClose, onSubmit }: BudgetImportModalProps) {
+  const [federalNumber, setFederalNumber] = useState('');
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (show) {
+      setTimeout(() => inputRef.current?.focus(), 180);
+    }
+  }, [show]);
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!federalNumber.trim()) {
+      return;
+    }
+    onSubmit(federalNumber.trim());
+  };
+
+  const handleHide = () => {
+    setFederalNumber('');
+    onClose();
+  };
+
+  return (
+    <Modal show={show} onHide={handleHide} centered>
+      <Form onSubmit={handleSubmit}>
+        <Modal.Header closeButton className="border-0 pb-0">
+          <Modal.Title className="fw-semibold text-uppercase">Importar presupuesto</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <p className="text-muted small mb-3">
+            Introduce el número federal asociado al presupuesto para traer los datos desde Pipedrive.
+          </p>
+          <Form.Group controlId="federalNumber">
+            <Form.Label className="fw-semibold">Número federal</Form.Label>
+            <Form.Control
+              ref={inputRef}
+              type="text"
+              placeholder="Ej. FED-00123"
+              value={federalNumber}
+              onChange={(event) => setFederalNumber(event.target.value)}
+              disabled={isLoading}
+              autoComplete="off"
+            />
+          </Form.Group>
+        </Modal.Body>
+        <Modal.Footer className="border-0 pt-0">
+          <Button variant="outline-secondary" onClick={handleHide} disabled={isLoading}>
+            Cancelar
+          </Button>
+          <Button type="submit" variant="primary" disabled={isLoading || !federalNumber.trim()}>
+            {isLoading ? 'Importando…' : 'Importar presupuesto'}
+          </Button>
+        </Modal.Footer>
+      </Form>
+    </Modal>
+  );
+}

--- a/frontend/src/features/presupuestos/BudgetTable.tsx
+++ b/frontend/src/features/presupuestos/BudgetTable.tsx
@@ -1,0 +1,55 @@
+import { Table } from 'react-bootstrap';
+import type { DealSummary } from '../../types/deal';
+
+interface BudgetTableProps {
+  budgets: DealSummary[];
+  onSelect: (budget: DealSummary) => void;
+}
+
+export function BudgetTable({ budgets, onSelect }: BudgetTableProps) {
+  if (!budgets.length) {
+    return (
+      <div className="text-center py-5 text-muted bg-white rounded-4 shadow-sm">
+        <p className="mb-1 fw-semibold">No hay presupuestos cargados todavía.</p>
+        <p className="mb-0 small">Importa un presupuesto para comenzar a planificar la formación.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="table-responsive rounded-4 shadow-sm bg-white">
+      <Table hover className="mb-0 align-middle">
+        <thead>
+          <tr>
+            <th scope="col">Presupuesto</th>
+            <th scope="col">Título</th>
+            <th scope="col">Cliente</th>
+            <th scope="col">Sede</th>
+            <th scope="col">Formación</th>
+          </tr>
+        </thead>
+        <tbody>
+          {budgets.map((budget) => (
+            <tr key={budget.dealId} role="button" onClick={() => onSelect(budget)}>
+              <td className="fw-semibold">#{budget.dealId}</td>
+              <td>{budget.title}</td>
+              <td>{budget.clientName}</td>
+              <td>{budget.sede}</td>
+              <td>
+                {budget.trainingNames.length ? (
+                  <ul className="list-unstyled mb-0 small">
+                    {budget.trainingNames.map((training) => (
+                      <li key={training}>{training}</li>
+                    ))}
+                  </ul>
+                ) : (
+                  <span className="text-muted">Sin productos formativos</span>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    </div>
+  );
+}

--- a/frontend/src/features/presupuestos/api.ts
+++ b/frontend/src/features/presupuestos/api.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+import type { DealSummary } from '../../types/deal';
+
+export interface ImportDealPayload {
+  federalNumber: string;
+}
+
+export async function importDeal(payload: ImportDealPayload): Promise<DealSummary> {
+  const { data } = await axios.post<DealSummary>('/api/deals/import', payload);
+  return data;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import 'bootstrap/dist/css/bootstrap.min.css';
+import './styles.css';
+import App from './App';
+
+const queryClient = new QueryClient();
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
+  </React.StrictMode>
+);

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,52 @@
+:root {
+  --color-red: #e8474d;
+  --color-red-soft: #f7c6c8;
+  --color-gray-dark: #2a2a2a;
+  --color-gray-medium: #565656;
+  --color-gray-light: #f2f2f2;
+  --color-background: #fafafa;
+  --font-family-base: 'Poppins', sans-serif;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-family-base);
+  background-color: var(--color-background);
+  color: var(--color-gray-dark);
+}
+
+.btn-primary {
+  background-color: var(--color-red);
+  border-color: var(--color-red);
+}
+
+.btn-primary:hover,
+.btn-primary:focus {
+  background-color: #d93b41;
+  border-color: #d93b41;
+}
+
+.nav-link {
+  font-weight: 500;
+  color: var(--color-gray-medium);
+}
+
+.nav-link.active {
+  color: var(--color-red);
+}
+
+.table thead {
+  background-color: var(--color-gray-light);
+}
+
+.table tbody tr {
+  transition: background-color 0.2s ease-in-out;
+}
+
+.table tbody tr:hover {
+  background-color: rgba(232, 71, 77, 0.08);
+}
+
+.modal-content {
+  border-radius: 18px;
+}

--- a/frontend/src/types/deal.ts
+++ b/frontend/src/types/deal.ts
@@ -1,0 +1,14 @@
+export interface DealSummary {
+  dealId: number;
+  title: string;
+  clientName: string;
+  sede: string;
+  trainingNames: string[];
+  trainingType?: string | null;
+  hours?: number | null;
+  caes?: string | null;
+  fundae?: string | null;
+  hotelNight?: string | null;
+  notes?: string[];
+  documents?: string[];
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "resolveJsonModule": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    open: true,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:4000',
+        changeOrigin: true
+      }
+    }
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "erp_gep",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Monorepo para el ERP interno de planificación de formaciones de GEP Group.",
+  "workspaces": [
+    "frontend",
+    "backend"
+  ],
+  "scripts": {
+    "dev:frontend": "npm --workspace frontend run dev",
+    "dev:backend": "npm --workspace backend run dev",
+    "lint": "npm --workspaces run lint"
+  }
+}


### PR DESCRIPTION
## Summary
- set up the monorepo structure with shared tooling, workspace scripts, and environment template
- scaffold the React + Bootstrap front end with the Presupuestos UI, modal workflows, and React Query wiring
- bootstrap the Express + Prisma back end with the deals import endpoint, Pipedrive sync service, and relational schema

## Testing
- `npm install` *(fails in sandbox: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d9772ea6f48328bf42ebd9a69eddd7