### PR TITLE
Fix Netlify bundling for Neon dependency

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,6 +10,7 @@
 [functions]
   directory = "netlify/functions"
   node_bundler = "esbuild"
+  external_node_modules = ["@neondatabase/serverless"]
 
 # Proxy: /api/* -> Function "api"
 [[redirects]]


### PR DESCRIPTION
## Summary
- keep the Neon serverless client external when bundling Netlify Functions to avoid resolution failures

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9a297f5d88328bafef1de87b42637