### PR TITLE
Ensure Neon driver bundled in Netlify functions

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,7 +10,7 @@
 [functions]
   directory = "netlify/functions"
   node_bundler = "esbuild"
-  external_node_modules = ["@neondatabase/serverless"]
+  included_files = ["node_modules/@neondatabase/serverless/**"]
 
 # Proxy: /api/* -> Function "api"
 [[redirects]]


### PR DESCRIPTION
## Summary
- include the Neon serverless driver when packaging Netlify functions to avoid missing module errors at runtime

## Testing
- npm run lint *(fails: ESLint 9 requires eslint.config.js in frontend and backend workspaces)*

------
https://chatgpt.com/codex/tasks/task_e_68d9a483166483289a0a2ced42dbe507