### PR TITLE
Ensure Neon driver is available in Netlify functions

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 # netlify.toml (en la RAÍZ del repo)
 [build]
   publish = "frontend/dist"
-  command = "npm ci && cd frontend && npm ci && npm run build"
+  command = "npm ci && npm --prefix netlify/functions install && cd frontend && npm ci && npm run build"
 
 [build.environment]
   NODE_VERSION = "20"
@@ -10,7 +10,10 @@
 [functions]
   directory = "netlify/functions"
   node_bundler = "esbuild"
-  included_files = ["node_modules/@neondatabase/serverless/**"]
+  included_files = [
+    "node_modules/@neondatabase/serverless/**",
+    "netlify/functions/node_modules/@neondatabase/serverless/**"
+  ]
 
 # Proxy: /api/* -> Function "api"
 [[redirects]]

--- a/netlify/functions/package.json
+++ b/netlify/functions/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "erp-gep-functions",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@neondatabase/serverless": "^0.10.4"
+  }
+}


### PR DESCRIPTION
## Summary
- install Netlify function dependencies during the build so the Neon driver is present at runtime
- add a local package manifest for Netlify functions and include its Neon module directory in the deployment bundle

## Testing
- not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d9a7eb654c83289fd8e292ac216742