### PR TITLE
Normaliza la URL base de Pipedrive

### DIFF
--- a/backend/src/services/pipedriveClient.ts
+++ b/backend/src/services/pipedriveClient.ts
@@ -1,8 +1,26 @@
 import axios from 'axios';
 import { env } from '../config/env';
 
+function normalizePipedriveBaseUrl(rawUrl: string): string {
+  const trimmed = rawUrl.trim().replace(/\/+$/, '');
+
+  if (!trimmed) {
+    return 'https://api.pipedrive.com/v1';
+  }
+
+  if (/\/api\/v\d+$/i.test(trimmed)) {
+    return trimmed;
+  }
+
+  if (/\/api$/i.test(trimmed)) {
+    return `${trimmed}/v1`;
+  }
+
+  return `${trimmed}/api/v1`;
+}
+
 export const pipedriveClient = axios.create({
-  baseURL: env.PIPEDRIVE_BASE_URL,
+  baseURL: normalizePipedriveBaseUrl(env.PIPEDRIVE_BASE_URL),
   params: {
     api_token: env.PIPEDRIVE_API_TOKEN
   }

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -18,8 +18,28 @@ const JSON_HEADERS = {
   "Access-Control-Allow-Headers": "Content-Type, Authorization",
 };
 
-const PIPEDRIVE_BASE_URL =
-  process.env.PIPEDRIVE_BASE_URL?.trim() || "https://api.pipedrive.com/v1";
+function normalizePipedriveBaseUrl(rawUrl: string | undefined | null): string {
+  const fallback = "https://api.pipedrive.com/v1";
+  if (!rawUrl) return fallback;
+
+  const trimmed = rawUrl.trim().replace(/\/+$/, "");
+
+  if (!trimmed) {
+    return fallback;
+  }
+
+  if (/\/api\/v\d+$/i.test(trimmed)) {
+    return trimmed;
+  }
+
+  if (/\/api$/i.test(trimmed)) {
+    return `${trimmed}/v1`;
+  }
+
+  return `${trimmed}/api/v1`;
+}
+
+const PIPEDRIVE_BASE_URL = normalizePipedriveBaseUrl(process.env.PIPEDRIVE_BASE_URL);
 const PIPEDRIVE_API_TOKEN = process.env.PIPEDRIVE_API_TOKEN?.trim() || "";
 const DATABASE_URL = process.env.DATABASE_URL?.trim() || "";
 


### PR DESCRIPTION
## Summary
- normaliza la URL base de Pipedrive en el backend para asegurar llamadas a la API v1
- ajusta la función serverless para reutilizar la normalización con valor por defecto seguro

## Testing
- npm --workspace backend run build *(fails: existing TypeScript errors en src/services/importDeal.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d9a9b8fd0c83289dc08afa128bfb8a