### PR TITLE
Fix budget import request payload

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,7 +18,7 @@ export default function App() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const importMutation = useMutation({
-    mutationFn: importDeal,
+    mutationFn: (federalNumber: string) => importDeal(federalNumber),
     onSuccess: (budget) => {
       setBudgets((previous) => {
         const filtered = previous.filter((item) => item.dealId !== budget.dealId);
@@ -129,7 +129,7 @@ export default function App() {
         show={showImportModal}
         isLoading={importMutation.isPending}
         onClose={() => setShowImportModal(false)}
-        onSubmit={(federalNumber) => importMutation.mutate({ federalNumber })}
+        onSubmit={(federalNumber) => importMutation.mutate(federalNumber)}
       />
       <BudgetDetailModal budget={selectedBudget} onClose={() => setSelectedBudget(null)} />
     </div>


### PR DESCRIPTION
## Summary
- ensure the budget import mutation sends the federal number string instead of an object
- call the import API with the correct argument type to avoid [object Object] identifiers

## Testing
- npm run build:frontend

------
https://chatgpt.com/codex/tasks/task_e_68dade2460bc8328a861a3e27a8ed1ac