### PR TITLE
Handle missing training names in budget views

### DIFF
--- a/backend/src/types/deal.ts
+++ b/backend/src/types/deal.ts
@@ -3,7 +3,7 @@ export interface DealSummary {
   title: string;
   clientName: string;
   sede: string;
-  trainingNames: string[];
+  trainingNames?: string[];
   trainingType?: string | null;
   hours?: number | null;
   caes?: string | null;

--- a/frontend/src/features/presupuestos/BudgetDetailModal.tsx
+++ b/frontend/src/features/presupuestos/BudgetDetailModal.tsx
@@ -28,7 +28,7 @@ export function BudgetDetailModal({ budget, onClose }: BudgetDetailModalProps) {
             </section>
             <section>
               <h6 className="text-uppercase text-muted fw-semibold small">Formación</h6>
-              {budget.trainingNames.length ? (
+              {Array.isArray(budget.trainingNames) && budget.trainingNames.length ? (
                 <div className="d-flex flex-wrap gap-2">
                   {budget.trainingNames.map((training) => (
                     <Badge bg="light" text="dark" key={training} className="px-3 py-2 rounded-pill">

--- a/frontend/src/features/presupuestos/BudgetTable.tsx
+++ b/frontend/src/features/presupuestos/BudgetTable.tsx
@@ -29,16 +29,19 @@ export function BudgetTable({ budgets, onSelect }: BudgetTableProps) {
           </tr>
         </thead>
         <tbody>
-          {budgets.map((budget) => (
-            <tr key={budget.dealId} role="button" onClick={() => onSelect(budget)}>
+          {budgets.map((budget) => {
+            const trainingNames = Array.isArray(budget.trainingNames) ? budget.trainingNames : [];
+
+            return (
+              <tr key={budget.dealId} role="button" onClick={() => onSelect(budget)}>
               <td className="fw-semibold">#{budget.dealId}</td>
               <td>{budget.title}</td>
               <td>{budget.clientName}</td>
               <td>{budget.sede}</td>
               <td>
-                {budget.trainingNames.length ? (
+                {trainingNames.length ? (
                   <ul className="list-unstyled mb-0 small">
-                    {budget.trainingNames.map((training) => (
+                    {trainingNames.map((training) => (
                       <li key={training}>{training}</li>
                     ))}
                   </ul>
@@ -46,8 +49,9 @@ export function BudgetTable({ budgets, onSelect }: BudgetTableProps) {
                   <span className="text-muted">Sin productos formativos</span>
                 )}
               </td>
-            </tr>
-          ))}
+              </tr>
+            );
+          })}
         </tbody>
       </Table>
     </div>

--- a/frontend/src/types/deal.ts
+++ b/frontend/src/types/deal.ts
@@ -3,7 +3,7 @@ export interface DealSummary {
   title: string;
   clientName: string;
   sede: string;
-  trainingNames: string[];
+  trainingNames?: string[];
   trainingType?: string | null;
   hours?: number | null;
   caes?: string | null;


### PR DESCRIPTION
## Summary
- guard budget table and detail modal against missing training names to avoid runtime crashes
- allow deal summary types to omit training names for legacy Pipedrive records

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dae13e967483288c7a1b1bf94402d0