### PR TITLE
fix: route deal imports through backend before falling back to Netlify

### DIFF
--- a/frontend/src/features/presupuestos/api.ts
+++ b/frontend/src/features/presupuestos/api.ts
@@ -1,15 +1,50 @@
 /**
  * API del feature Presupuestos.
- * Forzamos base a /.netlify/functions (robusto en producción).
- * Si existe VITE_API_BASE, la respeta (útil en local).
+ * Usa VITE_API_BASE si está definido. En caso contrario intenta primero el backend
+ * propio (`/api`) y, como compatibilidad, las funciones de Netlify (`/.netlify/functions`).
  */
 import type { DealSummary } from '../../types/deal';
 
 type Json = any;
 
-const API_BASE: string =
-  (import.meta as any)?.env?.VITE_API_BASE?.toString()?.trim() ||
-  '/.netlify/functions';
+type Endpoint = {
+  base: string;
+  path: string;
+};
+
+const rawApiBase = (import.meta as any)?.env?.VITE_API_BASE?.toString()?.trim() || '';
+
+function normalizeBase(base: string): string {
+  if (!base) return '';
+  return base.endsWith('/') ? base.replace(/\/+$/, '') : base;
+}
+
+function buildEndpoints(): Endpoint[] {
+  const base = normalizeBase(rawApiBase);
+
+  if (base) {
+    const isNetlifyFunctions = base.includes('.netlify/functions');
+    return [
+      {
+        base,
+        path: isNetlifyFunctions ? '/deals_import' : '/deals/import'
+      }
+    ];
+  }
+
+  return [
+    { base: '/api', path: '/deals/import' },
+    { base: '/.netlify/functions', path: '/deals_import' }
+  ];
+}
+
+const ENDPOINTS: Endpoint[] = buildEndpoints();
+
+function joinUrl(base: string, path: string): string {
+  const normalizedBase = normalizeBase(base) || '';
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  return `${normalizedBase}${normalizedPath}`;
+}
 
 function parseDealSummary(data: Json): DealSummary {
   const deal = data?.deal ?? data;
@@ -79,26 +114,46 @@ function parseDealSummary(data: Json): DealSummary {
 
 /** POST -> deals_import */
 export async function importPresupuesto(federalNumber: string): Promise<DealSummary> {
-  const res = await fetch(`${API_BASE}/deals_import`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ federalNumber })
-  });
+  const attempts: Array<{ url: string; error: string }> = [];
 
-  const text = await res.text();
-  let data: any = null;
-  try {
-    data = text ? JSON.parse(text) : null;
-  } catch {
-    // Si upstream devolviera HTML (404), deja un error legible
+  for (const endpoint of ENDPOINTS) {
+    const url = joinUrl(endpoint.base, endpoint.path);
+
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ federalNumber })
+      });
+
+      const text = await res.text();
+      let data: any = null;
+
+      if (text) {
+        try {
+          data = JSON.parse(text);
+        } catch (jsonError) {
+          throw new Error(`Respuesta no es JSON: ${(jsonError as Error).message}`);
+        }
+      }
+
+      if (!res.ok) {
+        const reason = (data && (data.error || data.message)) || `HTTP ${res.status}`;
+        throw new Error(`${reason} :: ${String(text).slice(0, 800)}`);
+      }
+
+      return parseDealSummary(data);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      attempts.push({ url, error: message });
+    }
   }
 
-  if (!res.ok) {
-    const reason = (data && (data.error || data.message)) || `HTTP ${res.status}`;
-    throw new Error(`${reason} :: ${String(text).slice(0, 800)}`);
-  }
+  const detail = attempts
+    .map((attempt) => `${attempt.url} → ${attempt.error}`)
+    .join(' | ');
 
-  return parseDealSummary(data);
+  throw new Error(`No se pudo importar el presupuesto. Intentos fallidos: ${detail}`);
 }
 
 /** Compatibilidad con código existente (App.tsx importa importDeal) */


### PR DESCRIPTION
## Summary
- update the Presupuestos API client to build endpoints dynamically and prefer the Express backend import route
- keep Netlify functions as a compatibility fallback and surface combined error details when every endpoint fails

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68dae88ef1c88328b8c7061a153747c0