### PR TITLE
Implement persistent deal import and budgets listing

### DIFF
--- a/frontend/src/features/presupuestos/BudgetDetailModal.tsx
+++ b/frontend/src/features/presupuestos/BudgetDetailModal.tsx
@@ -47,13 +47,33 @@ export function BudgetDetailModal({ budget, onClose }: BudgetDetailModalProps) {
                 <dd className="col-sm-8">{budget.trainingType ?? 'Pendiente de sincronizar'}</dd>
                 <dt className="col-sm-4 text-muted">Horas</dt>
                 <dd className="col-sm-8">{budget.hours ?? '—'}</dd>
+                <dt className="col-sm-4 text-muted">Dirección</dt>
+                <dd className="col-sm-8">{budget.dealDirection ?? '—'}</dd>
                 <dt className="col-sm-4 text-muted">CAES</dt>
                 <dd className="col-sm-8">{budget.caes ?? '—'}</dd>
                 <dt className="col-sm-4 text-muted">FUNDAE</dt>
                 <dd className="col-sm-8">{budget.fundae ?? '—'}</dd>
                 <dt className="col-sm-4 text-muted">Hotel y pernocta</dt>
                 <dd className="col-sm-8">{budget.hotelNight ?? '—'}</dd>
+                <dt className="col-sm-4 text-muted">Documentos</dt>
+                <dd className="col-sm-8">{budget.documentsNum ?? budget.documents?.length ?? 0}</dd>
+                <dt className="col-sm-4 text-muted">Notas</dt>
+                <dd className="col-sm-8">{budget.notesCount ?? budget.notes?.length ?? 0}</dd>
               </dl>
+            </section>
+            <section>
+              <h6 className="text-uppercase text-muted fw-semibold small">Productos extra</h6>
+              {Array.isArray(budget.prodExtraNames) && budget.prodExtraNames.length ? (
+                <div className="d-flex flex-wrap gap-2">
+                  {budget.prodExtraNames.map((extra) => (
+                    <Badge bg="light" text="dark" key={extra} className="px-3 py-2 rounded-pill border">
+                      {extra}
+                    </Badge>
+                  ))}
+                </div>
+              ) : (
+                <p className="mb-0 text-muted">Sin productos extra asociados.</p>
+              )}
             </section>
             <section>
               <h6 className="text-uppercase text-muted fw-semibold small">Documentos</h6>
@@ -78,6 +98,19 @@ export function BudgetDetailModal({ budget, onClose }: BudgetDetailModalProps) {
               ) : (
                 <p className="mb-0 text-muted">Aún no hay notas asociadas.</p>
               )}
+            </section>
+            <section>
+              <h6 className="text-uppercase text-muted fw-semibold small">Trazabilidad</h6>
+              <dl className="row mb-0 small">
+                <dt className="col-sm-4 text-muted">Deal ID</dt>
+                <dd className="col-sm-8">{budget.dealId}</dd>
+                <dt className="col-sm-4 text-muted">Organización ID</dt>
+                <dd className="col-sm-8">{budget.dealOrgId}</dd>
+                <dt className="col-sm-4 text-muted">Creado</dt>
+                <dd className="col-sm-8">{budget.createdAt ? new Date(budget.createdAt).toLocaleString() : '—'}</dd>
+                <dt className="col-sm-4 text-muted">Actualizado</dt>
+                <dd className="col-sm-8">{budget.updatedAt ? new Date(budget.updatedAt).toLocaleString() : '—'}</dd>
+              </dl>
             </section>
           </div>
         ) : null}

--- a/frontend/src/features/presupuestos/BudgetImportModal.tsx
+++ b/frontend/src/features/presupuestos/BudgetImportModal.tsx
@@ -5,11 +5,11 @@ interface BudgetImportModalProps {
   show: boolean;
   isLoading: boolean;
   onClose: () => void;
-  onSubmit: (federalNumber: string) => void;
+  onSubmit: (dealId: string) => void;
 }
 
 export function BudgetImportModal({ show, isLoading, onClose, onSubmit }: BudgetImportModalProps) {
-  const [federalNumber, setFederalNumber] = useState('');
+  const [dealId, setDealId] = useState('');
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
@@ -20,14 +20,14 @@ export function BudgetImportModal({ show, isLoading, onClose, onSubmit }: Budget
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!federalNumber.trim()) {
+    if (!dealId.trim()) {
       return;
     }
-    onSubmit(federalNumber.trim());
+    onSubmit(dealId.trim());
   };
 
   const handleHide = () => {
-    setFederalNumber('');
+    setDealId('');
     onClose();
   };
 
@@ -38,14 +38,14 @@ export function BudgetImportModal({ show, isLoading, onClose, onSubmit }: Budget
           <Modal.Title className="fw-semibold text-uppercase">Importar presupuesto</Modal.Title>
         </Modal.Header>
         <Modal.Body>
-          <Form.Group controlId="federalNumber">
-            <Form.Label className="fw-semibold">Presupuesto</Form.Label>
+          <Form.Group controlId="dealId">
+            <Form.Label className="fw-semibold">Presupuesto (dealId)</Form.Label>
             <Form.Control
               ref={inputRef}
               type="text"
-              placeholder="Ej. 0123"
-              value={federalNumber}
-              onChange={(event) => setFederalNumber(event.target.value)}
+              placeholder="Ej. 7222"
+              value={dealId}
+              onChange={(event) => setDealId(event.target.value)}
               disabled={isLoading}
               autoComplete="off"
             />
@@ -55,7 +55,7 @@ export function BudgetImportModal({ show, isLoading, onClose, onSubmit }: Budget
           <Button variant="outline-secondary" onClick={handleHide} disabled={isLoading}>
             Cancelar
           </Button>
-          <Button type="submit" variant="primary" disabled={isLoading || !federalNumber.trim()}>
+          <Button type="submit" variant="primary" disabled={isLoading || !dealId.trim()}>
             {isLoading ? 'Importando…' : 'Importar presupuesto'}
           </Button>
         </Modal.Footer>

--- a/frontend/src/features/presupuestos/BudgetTable.tsx
+++ b/frontend/src/features/presupuestos/BudgetTable.tsx
@@ -1,16 +1,71 @@
-import { Table } from 'react-bootstrap';
+import { Alert, Badge, Button, Spinner, Table } from 'react-bootstrap';
 import type { DealSummary } from '../../types/deal';
 
 interface BudgetTableProps {
   budgets: DealSummary[];
+  isLoading: boolean;
+  isFetching: boolean;
+  error: unknown;
+  onRetry: () => void;
   onSelect: (budget: DealSummary) => void;
 }
 
-export function BudgetTable({ budgets, onSelect }: BudgetTableProps) {
+function formatDate(value?: string): string {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '—';
+  return new Intl.DateTimeFormat('es-ES', { dateStyle: 'short', timeStyle: 'short' }).format(date);
+}
+
+function formatList(values?: string[]): JSX.Element | string {
+  if (!values?.length) {
+    return <span className="text-muted">Sin datos</span>;
+  }
+
+  if (values.length === 1) {
+    return values[0];
+  }
+
+  return (
+    <ul className="list-unstyled mb-0 small">
+      {values.map((value) => (
+        <li key={value}>{value}</li>
+      ))}
+    </ul>
+  );
+}
+
+export function BudgetTable({ budgets, isLoading, isFetching, error, onRetry, onSelect }: BudgetTableProps) {
+  if (isLoading) {
+    return (
+      <div className="text-center py-5 text-muted bg-white rounded-4 shadow-sm">
+        <Spinner animation="border" role="status" className="mb-3" />
+        <p className="mb-0">Cargando presupuestos desde la base de datos…</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    const message = error instanceof Error ? error.message : 'No se pudo cargar el listado de presupuestos.';
+    return (
+      <Alert variant="danger" className="rounded-4 shadow-sm d-flex flex-column flex-md-row align-items-md-center gap-3">
+        <div className="flex-grow-1">
+          <p className="fw-semibold mb-1">Error al cargar presupuestos</p>
+          <p className="mb-0 small">{message}</p>
+        </div>
+        <div>
+          <Button variant="outline-danger" onClick={onRetry}>
+            Reintentar
+          </Button>
+        </div>
+      </Alert>
+    );
+  }
+
   if (!budgets.length) {
     return (
       <div className="text-center py-5 text-muted bg-white rounded-4 shadow-sm">
-        <p className="mb-1 fw-semibold">No hay presupuestos cargados todavía.</p>
+        <p className="mb-1 fw-semibold">No hay presupuestos sin sesiones pendientes.</p>
         <p className="mb-0 small">Importa un presupuesto para comenzar a planificar la formación.</p>
       </div>
     );
@@ -18,37 +73,65 @@ export function BudgetTable({ budgets, onSelect }: BudgetTableProps) {
 
   return (
     <div className="table-responsive rounded-4 shadow-sm bg-white">
+      {isFetching && (
+        <div className="d-flex align-items-center gap-2 px-3 py-2 border-bottom text-muted small">
+          <Spinner animation="border" size="sm" />
+          <span>Actualizando listado…</span>
+        </div>
+      )}
       <Table hover className="mb-0 align-middle">
         <thead>
           <tr>
             <th scope="col">Presupuesto</th>
-            <th scope="col">Título</th>
             <th scope="col">Cliente</th>
             <th scope="col">Sede</th>
             <th scope="col">Formación</th>
+            <th scope="col">Horas</th>
+            <th scope="col">Dirección</th>
+            <th scope="col">CAES</th>
+            <th scope="col">FUNDAE</th>
+            <th scope="col">Hotel</th>
+            <th scope="col">Docs</th>
+            <th scope="col">Actualizado</th>
           </tr>
         </thead>
         <tbody>
           {budgets.map((budget) => {
-            const trainingNames = Array.isArray(budget.trainingNames) ? budget.trainingNames : [];
+            const trainingNames = Array.isArray(budget.trainingNames) ? budget.trainingNames : undefined;
+            const prodExtraNames = Array.isArray(budget.prodExtraNames) ? budget.prodExtraNames : undefined;
+            const documentsNum = budget.documentsNum ?? budget.documents?.length ?? 0;
+            const notesCount = budget.notesCount ?? budget.notes?.length ?? 0;
 
             return (
               <tr key={budget.dealId} role="button" onClick={() => onSelect(budget)}>
-              <td className="fw-semibold">#{budget.dealId}</td>
-              <td>{budget.title}</td>
-              <td>{budget.clientName}</td>
-              <td>{budget.sede}</td>
-              <td>
-                {trainingNames.length ? (
-                  <ul className="list-unstyled mb-0 small">
-                    {trainingNames.map((training) => (
-                      <li key={training}>{training}</li>
-                    ))}
-                  </ul>
-                ) : (
-                  <span className="text-muted">Sin productos formativos</span>
-                )}
-              </td>
+                <td className="fw-semibold">#{budget.dealId}</td>
+                <td>
+                  <div className="fw-semibold">{budget.clientName}</div>
+                  <div className="text-muted small">ID Org: {budget.dealOrgId}</div>
+                </td>
+                <td>{budget.sede}</td>
+                <td className="small">
+                  {formatList(trainingNames)}
+                  {prodExtraNames && prodExtraNames.length ? (
+                    <div className="mt-2 d-flex flex-wrap gap-1">
+                      {prodExtraNames.map((extra) => (
+                        <Badge bg="light" text="dark" key={extra} className="border">
+                          Extra: {extra}
+                        </Badge>
+                      ))}
+                    </div>
+                  ) : null}
+                </td>
+                <td>{budget.hours ?? '—'}</td>
+                <td>{budget.dealDirection ?? '—'}</td>
+                <td>{budget.caes ?? '—'}</td>
+                <td>{budget.fundae ?? '—'}</td>
+                <td>{budget.hotelNight ?? '—'}</td>
+                <td>
+                  <div>{documentsNum}</div>
+                  <div className="text-muted small">Notas: {notesCount}</div>
+                </td>
+                <td>{formatDate(budget.updatedAt)}</td>
               </tr>
             );
           })}

--- a/frontend/src/features/presupuestos/api.ts
+++ b/frontend/src/features/presupuestos/api.ts
@@ -1,16 +1,8 @@
-/**
- * API del feature Presupuestos.
- * Usa VITE_API_BASE si está definido. En caso contrario intenta primero el backend
- * propio (`/api`) y, como compatibilidad, las funciones de Netlify (`/.netlify/functions`).
- */
-import type { DealSummary } from '../../types/deal';
+import type { DealSummary, TrainingProduct } from '../../types/deal';
 
 type Json = any;
 
-type Endpoint = {
-  base: string;
-  path: string;
-};
+type Attempt = { url: string; error: string };
 
 const rawApiBase = (import.meta as any)?.env?.VITE_API_BASE?.toString()?.trim() || '';
 
@@ -19,26 +11,19 @@ function normalizeBase(base: string): string {
   return base.endsWith('/') ? base.replace(/\/+$/, '') : base;
 }
 
-function buildEndpoints(): Endpoint[] {
-  const base = normalizeBase(rawApiBase);
-
-  if (base) {
-    const isNetlifyFunctions = base.includes('.netlify/functions');
-    return [
-      {
-        base,
-        path: isNetlifyFunctions ? '/deals_import' : '/deals/import'
-      }
-    ];
-  }
-
-  return [
-    { base: '/api', path: '/deals/import' },
-    { base: '/.netlify/functions', path: '/deals_import' }
-  ];
+function isNetlifyFunctionsBase(base: string): boolean {
+  return base.includes('.netlify/functions');
 }
 
-const ENDPOINTS: Endpoint[] = buildEndpoints();
+function getApiBases(): string[] {
+  const base = normalizeBase(rawApiBase);
+  if (base) {
+    return [base];
+  }
+  return ['/api', '/.netlify/functions'];
+}
+
+const API_BASES = getApiBases();
 
 function joinUrl(base: string, path: string): string {
   const normalizedBase = normalizeBase(base) || '';
@@ -46,115 +31,273 @@ function joinUrl(base: string, path: string): string {
   return `${normalizedBase}${normalizedPath}`;
 }
 
-function parseDealSummary(data: Json): DealSummary {
+function withQuery(url: string, query: Record<string, string | number | boolean | undefined>): string {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(query)) {
+    if (value === undefined) continue;
+    params.set(key, String(value));
+  }
+  const queryString = params.toString();
+  if (!queryString) return url;
+  return `${url}${url.includes('?') ? '&' : '?'}${queryString}`;
+}
+
+function toNumber(value: unknown): number | null {
+  if (value === null || value === undefined || value === '') return null;
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
+function parseTrainingProducts(value: unknown): TrainingProduct[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((item) => {
+    const quantity = toNumber((item as any)?.quantity);
+    const code = (item as any)?.code ?? (item as any)?.product_code ?? null;
+    const productId = (item as any)?.product_id ?? (item as any)?.id ?? null;
+    return {
+      product_id: toNumber(productId),
+      name: typeof (item as any)?.name === 'string' ? (item as any).name : null,
+      code: typeof code === 'string' ? code : code != null ? String(code) : null,
+      quantity: quantity ?? 0
+    };
+  });
+}
+
+function toStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const list = value
+    .map((entry) => (entry == null ? null : typeof entry === 'string' ? entry : String(entry)))
+    .filter((entry): entry is string => Boolean(entry?.trim()));
+  return list.length ? list : undefined;
+}
+
+function parseDealPayload(data: Json): DealSummary {
   const deal = data?.deal ?? data;
   if (!deal || typeof deal !== 'object') {
     throw new Error('La respuesta de la API no contiene información del presupuesto.');
   }
 
-  const dealId = Number(deal.dealId ?? deal.id);
-  if (!Number.isFinite(dealId)) {
+  const dealId = toNumber(deal.dealId ?? deal.deal_id ?? deal.id);
+  if (!dealId) {
     throw new Error('La API no ha devuelto un identificador válido del presupuesto.');
   }
 
+  const dealOrgId =
+    toNumber(deal.dealOrgId ?? deal.deal_org_id ?? deal.org_id ?? deal.organizationId ?? deal.orgId) ?? 0;
+
+  const organizationName =
+    typeof deal.organizationName === 'string'
+      ? deal.organizationName
+      : typeof deal.organization_name === 'string'
+        ? deal.organization_name
+        : typeof deal.clientName === 'string'
+          ? deal.clientName
+          : typeof deal.client_name === 'string'
+            ? deal.client_name
+            : 'Organización sin nombre';
+
+  const trainingProducts = parseTrainingProducts(deal.training ?? deal.training_products);
+  const trainingNames =
+    toStringArray(deal.trainingNames) ??
+    toStringArray(deal.training_names) ??
+    (trainingProducts.length
+      ? trainingProducts
+          .map((product) => (product.name ?? '')?.toString().trim())
+          .filter(Boolean) as string[]
+      : undefined);
+
+  const prodExtra = parseTrainingProducts(deal.prodExtra ?? deal.prod_extra);
+  const prodExtraNames =
+    toStringArray(deal.prodExtraNames) ??
+    toStringArray(deal.prod_extra_names) ??
+    (prodExtra.length
+      ? prodExtra
+          .map((product) => (product.name ?? '')?.toString().trim())
+          .filter(Boolean) as string[]
+      : undefined);
+
+  const documents = toStringArray(deal.documents);
+  const documentsIdRaw = Array.isArray(deal.documentsId)
+    ? deal.documentsId
+    : Array.isArray(deal.documents_id)
+      ? deal.documents_id
+      : undefined;
+  const documentsId = documentsIdRaw
+    ? documentsIdRaw
+        .map((value) => toNumber(value))
+        .filter((value): value is number => typeof value === 'number')
+    : undefined;
+
+  const notes = toStringArray(deal.notes);
+
+  const trainingType =
+    typeof deal.trainingType === 'string'
+      ? deal.trainingType
+      : typeof deal.training_type === 'string'
+        ? deal.training_type
+        : undefined;
+
+  const hours = toNumber(deal.hours ?? deal.hours_value);
+
+  const dealDirection =
+    typeof deal.deal_direction === 'string'
+      ? deal.deal_direction
+      : typeof deal.direction === 'string'
+        ? deal.direction
+        : undefined;
+
+  const caes =
+    typeof deal.caes === 'string'
+      ? deal.caes
+      : typeof deal.caes_code === 'string'
+        ? deal.caes_code
+        : undefined;
+
+  const fundae =
+    typeof deal.fundae === 'string'
+      ? deal.fundae
+      : typeof deal.fundae_code === 'string'
+        ? deal.fundae_code
+        : undefined;
+
+  const hotelNight =
+    typeof deal.hotelNight === 'string'
+      ? deal.hotelNight
+      : typeof deal.hotel_night === 'string'
+        ? deal.hotel_night
+        : undefined;
+
+  const documentsNum =
+    toNumber(deal.documentsNum ?? deal.documents_num) ?? (documents ? documents.length : undefined);
+
+  const notesCount = toNumber(deal.notesCount ?? deal.notes_count) ?? (notes ? notes.length : undefined);
+
+  const sede =
+    typeof deal.sede === 'string'
+      ? deal.sede
+      : typeof deal.branch === 'string'
+        ? deal.branch
+        : '—';
+
   return {
     dealId,
+    dealOrgId,
+    organizationName,
     title: typeof deal.title === 'string' ? deal.title : `Presupuesto ${dealId}`,
     clientName:
       typeof deal.clientName === 'string'
         ? deal.clientName
         : typeof deal.client_name === 'string'
           ? deal.client_name
-          : 'Cliente sin nombre',
-    sede:
-      typeof deal.sede === 'string'
-        ? deal.sede
-        : typeof deal.branch === 'string'
-          ? deal.branch
-          : '—',
-    trainingNames: Array.isArray(deal.trainingNames)
-      ? deal.trainingNames
-      : Array.isArray(deal.training_names)
-        ? deal.training_names
-        : undefined,
-    trainingType:
-      typeof deal.trainingType === 'string'
-        ? deal.trainingType
-        : typeof deal.training_type === 'string'
-          ? deal.training_type
+          : organizationName,
+    sede,
+    trainingNames,
+    training: trainingProducts.length ? trainingProducts : undefined,
+    trainingType,
+    hours,
+    dealDirection,
+    caes,
+    fundae,
+    hotelNight,
+    prodExtra: prodExtra.length ? prodExtra : undefined,
+    prodExtraNames,
+    documentsNum,
+    documentsId,
+    documents,
+    notesCount,
+    notes,
+    createdAt:
+      typeof deal.created_at === 'string'
+        ? deal.created_at
+        : typeof deal.createdAt === 'string'
+          ? deal.createdAt
           : undefined,
-    hours:
-      deal.hours != null
-        ? Number.isFinite(Number(deal.hours))
-          ? Number(deal.hours)
-          : null
-        : deal.hours,
-    caes:
-      typeof deal.caes === 'string'
-        ? deal.caes
-        : typeof deal.caes_code === 'string'
-          ? deal.caes_code
-          : undefined,
-    fundae:
-      typeof deal.fundae === 'string'
-        ? deal.fundae
-        : typeof deal.fundae_code === 'string'
-          ? deal.fundae_code
-          : undefined,
-    hotelNight:
-      typeof deal.hotelNight === 'string'
-        ? deal.hotelNight
-        : typeof deal.hotel_night === 'string'
-          ? deal.hotel_night
-          : undefined,
-    notes: Array.isArray(deal.notes) ? deal.notes : undefined,
-    documents: Array.isArray(deal.documents) ? deal.documents : undefined
+    updatedAt:
+      typeof deal.updated_at === 'string'
+        ? deal.updated_at
+        : typeof deal.updatedAt === 'string'
+          ? deal.updatedAt
+          : undefined
   };
 }
 
-/** POST -> deals_import */
-export async function importPresupuesto(federalNumber: string): Promise<DealSummary> {
-  const attempts: Array<{ url: string; error: string }> = [];
+async function parseJsonResponse(response: Response): Promise<Json> {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new Error(`Respuesta no es JSON: ${(error as Error).message}`);
+  }
+}
 
-  for (const endpoint of ENDPOINTS) {
-    const url = joinUrl(endpoint.base, endpoint.path);
+function buildImportUrl(base: string): string {
+  const path = isNetlifyFunctionsBase(base) ? '/deals_import' : '/deals/import';
+  return joinUrl(base, path);
+}
+
+function buildDealsUrl(base: string): string {
+  const path = isNetlifyFunctionsBase(base) ? '/deals' : '/deals';
+  return withQuery(joinUrl(base, path), { noSessions: true });
+}
+
+function formatAttempts(attempts: Attempt[]): string {
+  return attempts.map((attempt) => `${attempt.url} → ${attempt.error}`).join(' | ');
+}
+
+export async function importPresupuesto(dealId: string): Promise<DealSummary> {
+  const attempts: Attempt[] = [];
+
+  for (const base of API_BASES) {
+    const url = buildImportUrl(base);
 
     try {
-      const res = await fetch(url, {
+      const response = await fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ federalNumber })
+        body: JSON.stringify({ dealId })
       });
 
-      const text = await res.text();
-      let data: any = null;
+      const data = await parseJsonResponse(response);
 
-      if (text) {
-        try {
-          data = JSON.parse(text);
-        } catch (jsonError) {
-          throw new Error(`Respuesta no es JSON: ${(jsonError as Error).message}`);
-        }
+      if (!response.ok) {
+        const reason = (data && (data.error || data.message)) || `HTTP ${response.status}`;
+        throw new Error(reason);
       }
 
-      if (!res.ok) {
-        const reason = (data && (data.error || data.message)) || `HTTP ${res.status}`;
-        throw new Error(`${reason} :: ${String(text).slice(0, 800)}`);
-      }
-
-      return parseDealSummary(data);
+      return parseDealPayload(data);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       attempts.push({ url, error: message });
     }
   }
 
-  const detail = attempts
-    .map((attempt) => `${attempt.url} → ${attempt.error}`)
-    .join(' | ');
-
-  throw new Error(`No se pudo importar el presupuesto. Intentos fallidos: ${detail}`);
+  throw new Error(`No se pudo importar el presupuesto. Intentos fallidos: ${formatAttempts(attempts)}`);
 }
 
-/** Compatibilidad con código existente (App.tsx importa importDeal) */
+export async function fetchDealsWithoutSessions(): Promise<DealSummary[]> {
+  const attempts: Attempt[] = [];
+
+  for (const base of API_BASES) {
+    const url = buildDealsUrl(base);
+    try {
+      const response = await fetch(url, { method: 'GET' });
+      const data = await parseJsonResponse(response);
+
+      if (!response.ok) {
+        const reason = (data && (data.error || data.message)) || `HTTP ${response.status}`;
+        throw new Error(reason);
+      }
+
+      const deals = Array.isArray(data?.deals) ? data.deals : Array.isArray(data) ? data : [];
+      return deals.map((deal: Json) => parseDealPayload(deal));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      attempts.push({ url, error: message });
+    }
+  }
+
+  throw new Error(`No se pudo obtener el listado de presupuestos. Intentos fallidos: ${formatAttempts(attempts)}`);
+}
+
 export const importDeal = importPresupuesto;

--- a/frontend/src/types/deal.ts
+++ b/frontend/src/types/deal.ts
@@ -1,14 +1,32 @@
+export interface TrainingProduct {
+  product_id: number | null;
+  name: string | null;
+  code: string | null;
+  quantity: number;
+}
+
 export interface DealSummary {
   dealId: number;
+  dealOrgId: number;
+  organizationName: string;
   title: string;
   clientName: string;
   sede: string;
   trainingNames?: string[];
+  training?: TrainingProduct[];
   trainingType?: string | null;
   hours?: number | null;
+  dealDirection?: string | null;
   caes?: string | null;
   fundae?: string | null;
   hotelNight?: string | null;
-  notes?: string[];
+  prodExtra?: TrainingProduct[];
+  prodExtraNames?: string[];
+  documentsNum?: number;
+  documentsId?: number[];
   documents?: string[];
+  notesCount?: number;
+  notes?: string[];
+  createdAt?: string;
+  updatedAt?: string;
 }

--- a/netlify/functions/deals.js
+++ b/netlify/functions/deals.js
@@ -1,0 +1,124 @@
+const { PrismaClient } = require('@prisma/client');
+const crypto = require('crypto');
+
+const COMMON_HEADERS = {
+  'Content-Type': 'application/json; charset=utf-8',
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST,OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type,Authorization'
+};
+
+let prisma;
+function getPrisma() {
+  if (!prisma) {
+    prisma = new PrismaClient();
+  }
+  return prisma;
+}
+
+function jsonResponse(statusCode, body) {
+  return { statusCode, headers: COMMON_HEADERS, body: JSON.stringify(body) };
+}
+
+function sanitizeHtml(html) {
+  if (!html) return null;
+  const text = String(html)
+    .replace(/<br\s*\/?>(\r?\n)?/gi, '\n')
+    .replace(/<li[^>]*>/gi, '• ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return text || null;
+}
+
+function normalizeJsonArray(value) {
+  if (!value) return [];
+  return Array.isArray(value) ? value : [];
+}
+
+function mapDealRecord(record) {
+  const training = normalizeJsonArray(record.training);
+  const prodExtra = normalizeJsonArray(record.prodExtra);
+  const documents = Array.isArray(record.documents) ? record.documents : [];
+  const notes = Array.isArray(record.notes) ? record.notes : [];
+  const trainingNames = training
+    .map((product) => (product && typeof product.name === 'string' ? product.name : null))
+    .filter(Boolean);
+  const extraNames = prodExtra
+    .map((product) => (product && typeof product.name === 'string' ? product.name : null))
+    .filter(Boolean);
+
+  return {
+    deal_id: record.id,
+    deal_org_id: record.organizationId,
+    organization_name: record.organization?.name ?? 'Organización sin nombre',
+    title: record.title,
+    training_type: record.trainingType ?? null,
+    training,
+    training_names: trainingNames,
+    hours: record.hours,
+    deal_direction: record.direction ?? null,
+    sede: record.sede ?? null,
+    caes: record.caes ?? null,
+    fundae: record.fundae ?? null,
+    hotel_night: record.hotelNight ?? null,
+    prod_extra: prodExtra,
+    prod_extra_names: extraNames,
+    documents_num: record.documentsNum ?? documents.length,
+    documents_id: documents.map((doc) => doc.id),
+    documents: documents.map((doc) => doc.title),
+    notes_count: record.notesNum ?? notes.length,
+    notes: notes.map((note) => sanitizeHtml(note.comment) ?? note.comment),
+    created_at: record.createdAt?.toISOString?.() ?? record.createdAt,
+    updated_at: record.updatedAt?.toISOString?.() ?? record.updatedAt
+  };
+}
+
+exports.handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 204, headers: COMMON_HEADERS, body: '' };
+  }
+
+  const requestId = crypto.randomUUID();
+
+  try {
+    if (event.httpMethod !== 'GET') {
+      return jsonResponse(405, { error: 'method_not_allowed', message: 'Método no permitido' });
+    }
+
+    const noSessionsRaw = event.queryStringParameters?.noSessions ?? event.queryStringParameters?.no_sessions;
+    const noSessions = typeof noSessionsRaw === 'string' ? noSessionsRaw.toLowerCase() === 'true' : false;
+
+    const prismaClient = getPrisma();
+
+    const deals = await prismaClient.deal.findMany({
+      where: noSessions
+        ? {
+            sessions: { none: {} }
+          }
+        : {},
+      include: {
+        organization: true,
+        notes: true,
+        documents: true
+      },
+      orderBy: { createdAt: 'desc' }
+    });
+
+    const payload = deals.map(mapDealRecord);
+
+    return jsonResponse(200, {
+      ok: true,
+      requestId,
+      count: payload.length,
+      deals: payload
+    });
+  } catch (error) {
+    console.error(`[${requestId}] deals list error`, error);
+    return jsonResponse(500, {
+      error: 'unexpected_error',
+      message: error instanceof Error ? error.message : 'Error inesperado',
+      requestId
+    });
+  }
+};

--- a/package.json
+++ b/package.json
@@ -6,9 +6,11 @@
     "db:init": "dotenv -e .env -- node scripts/init-db.mjs"
   },
   "dependencies": {
-    "@neondatabase/serverless": "^1.0.1"
+    "@neondatabase/serverless": "^1.0.1",
+    "@prisma/client": "^5.22.0"
   },
   "devDependencies": {
-    "dotenv-cli": "^10.0.0"
+    "dotenv-cli": "^10.0.0",
+    "prisma": "^5.22.0"
   }
 }


### PR DESCRIPTION
## Summary
- replace the Netlify deal import function with a Prisma-backed implementation that upserts organizations, people, deals, notes and documents atomically and returns the normalized payload
- add a Netlify deals listing function that exposes deals without sessions directly from the database for the budgets table
- update the budgets UI to rely on React Query/DB data, expanding the table/detail views and aligning the import modal and API helpers with the new schema

## Testing
- npm run build:frontend

------
https://chatgpt.com/codex/tasks/task_e_68daecd0ff088328ac17a60c834722ec