### PR TITLE
Implement manual budget refresh and detailed deal view

### DIFF
--- a/frontend/src/features/presupuestos/BudgetDetailModal.tsx
+++ b/frontend/src/features/presupuestos/BudgetDetailModal.tsx
@@ -1,37 +1,117 @@
-import { Modal, Badge } from 'react-bootstrap';
+import { Alert, Badge, Modal, Spinner } from 'react-bootstrap';
+import { useQuery } from '@tanstack/react-query';
+import { fetchDealDetail } from './api';
 import type { DealSummary } from '../../types/deal';
 
 interface BudgetDetailModalProps {
-  budget: DealSummary | null;
+  dealId: number | null;
+  summary: DealSummary | null;
   onClose: () => void;
 }
 
-export function BudgetDetailModal({ budget, onClose }: BudgetDetailModalProps) {
+function formatDate(value?: string): string {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '—';
+  return new Intl.DateTimeFormat('es-ES', { dateStyle: 'short', timeStyle: 'short' }).format(date);
+}
+
+function getTrainingNames(budget: DealSummary | null): string[] {
+  if (!budget) return [];
+  if (Array.isArray(budget.trainingNames) && budget.trainingNames.length) {
+    return budget.trainingNames;
+  }
+  if (Array.isArray(budget.training) && budget.training.length) {
+    return budget.training
+      .map((product) => (product.name ?? product.code ?? '')?.toString().trim())
+      .filter((value): value is string => Boolean(value));
+  }
+  return [];
+}
+
+export function BudgetDetailModal({ dealId, summary, onClose }: BudgetDetailModalProps) {
+  const detailQuery = useQuery({
+    queryKey: ['deal', dealId],
+    queryFn: () => fetchDealDetail(dealId as number),
+    enabled: typeof dealId === 'number',
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    refetchInterval: false,
+    retry: 0,
+    staleTime: Infinity
+  });
+
+  const deal = detailQuery.data ?? summary;
+  const isLoading = detailQuery.isFetching && !detailQuery.data;
+  const hasError = Boolean(detailQuery.error);
+  const errorMessage = detailQuery.error instanceof Error ? detailQuery.error.message : 'No se pudieron cargar los detalles.';
+
+  const trainingNames = getTrainingNames(deal);
+  const prodExtraNames = Array.isArray(deal?.prodExtraNames) ? deal?.prodExtraNames : [];
+  const documents = Array.isArray(deal?.documents) ? deal?.documents : [];
+  const documentsUrls = Array.isArray(deal?.documentsUrls) ? deal?.documentsUrls : [];
+  const notes = Array.isArray(deal?.notes) ? deal?.notes : [];
+  const participants = Array.isArray(deal?.participants) ? deal?.participants : [];
+
+  const documentEntries = documents.map((title, index) => ({
+    title,
+    url: documentsUrls[index] ?? null
+  }));
+
+  const showModal = typeof dealId === 'number';
+
   return (
-    <Modal show={!!budget} onHide={onClose} centered size="lg">
+    <Modal show={showModal} onHide={onClose} centered size="lg">
       <Modal.Header closeButton className="border-0 pb-0">
         <Modal.Title className="fw-semibold text-uppercase">
-          {budget ? `Presupuesto #${budget.dealId}` : 'Presupuesto'}
+          {deal ? `Presupuesto #${deal.dealId}` : 'Presupuesto'}
         </Modal.Title>
       </Modal.Header>
-      <Modal.Body>
-        {budget ? (
+      <Modal.Body className="d-grid gap-3">
+        {isLoading ? (
+          <div className="d-flex align-items-center gap-2 text-muted small">
+            <Spinner animation="border" size="sm" />
+            <span>Obteniendo datos del presupuesto…</span>
+          </div>
+        ) : null}
+
+        {hasError ? (
+          <Alert variant="danger" className="mb-0">
+            {errorMessage}
+          </Alert>
+        ) : null}
+
+        {deal ? (
           <div className="d-grid gap-4">
             <section>
               <h6 className="text-uppercase text-muted fw-semibold small">Resumen</h6>
-              <p className="mb-1 fw-semibold">{budget.title}</p>
-              <p className="mb-0 text-muted">{budget.clientName}</p>
+              <p className="mb-1 fw-semibold">{deal.title}</p>
+              <p className="mb-0 text-muted">{deal.organizationName}</p>
             </section>
+
+            <section>
+              <h6 className="text-uppercase text-muted fw-semibold small">Organización</h6>
+              <dl className="row mb-0 small">
+                <dt className="col-sm-4 text-muted">CIF</dt>
+                <dd className="col-sm-8">{deal.organizationCif ?? '—'}</dd>
+                <dt className="col-sm-4 text-muted">Teléfono</dt>
+                <dd className="col-sm-8">{deal.organizationPhone ?? '—'}</dd>
+                <dt className="col-sm-4 text-muted">Dirección</dt>
+                <dd className="col-sm-8">{deal.organizationAddress ?? '—'}</dd>
+              </dl>
+            </section>
+
             <section>
               <h6 className="text-uppercase text-muted fw-semibold small">Sede</h6>
-              <p className="mb-0">{budget.sede}</p>
+              <p className="mb-0">{deal.sede ?? '—'}</p>
             </section>
+
             <section>
               <h6 className="text-uppercase text-muted fw-semibold small">Formación</h6>
-              {Array.isArray(budget.trainingNames) && budget.trainingNames.length ? (
+              {trainingNames.length ? (
                 <div className="d-flex flex-wrap gap-2">
-                  {budget.trainingNames.map((training) => (
-                    <Badge bg="light" text="dark" key={training} className="px-3 py-2 rounded-pill">
+                  {trainingNames.map((training) => (
+                    <Badge bg="light" text="dark" key={training} className="px-3 py-2 rounded-pill border">
                       {training}
                     </Badge>
                   ))}
@@ -39,59 +119,61 @@ export function BudgetDetailModal({ budget, onClose }: BudgetDetailModalProps) {
               ) : (
                 <p className="mb-0 text-muted">Sin productos formativos vinculados.</p>
               )}
+              {prodExtraNames.length ? (
+                <div className="d-flex flex-wrap gap-2 mt-3">
+                  {prodExtraNames.map((extra) => (
+                    <Badge bg="secondary" key={extra} className="px-3 py-2 rounded-pill">
+                      Extra: {extra}
+                    </Badge>
+                  ))}
+                </div>
+              ) : null}
             </section>
+
             <section>
               <h6 className="text-uppercase text-muted fw-semibold small">Detalles operativos</h6>
               <dl className="row mb-0 small">
                 <dt className="col-sm-4 text-muted">Tipo de formación</dt>
-                <dd className="col-sm-8">{budget.trainingType ?? 'Pendiente de sincronizar'}</dd>
+                <dd className="col-sm-8">{deal.trainingType ?? 'Pendiente de sincronizar'}</dd>
                 <dt className="col-sm-4 text-muted">Horas</dt>
-                <dd className="col-sm-8">{budget.hours ?? '—'}</dd>
+                <dd className="col-sm-8">{deal.hours ?? '—'}</dd>
                 <dt className="col-sm-4 text-muted">Dirección</dt>
-                <dd className="col-sm-8">{budget.dealDirection ?? '—'}</dd>
-                <dt className="col-sm-4 text-muted">CAES</dt>
-                <dd className="col-sm-8">{budget.caes ?? '—'}</dd>
+                <dd className="col-sm-8">{deal.dealDirection ?? '—'}</dd>
+                <dt className="col-sm-4 text-muted">CAE</dt>
+                <dd className="col-sm-8">{deal.caes ?? '—'}</dd>
                 <dt className="col-sm-4 text-muted">FUNDAE</dt>
-                <dd className="col-sm-8">{budget.fundae ?? '—'}</dd>
-                <dt className="col-sm-4 text-muted">Hotel y pernocta</dt>
-                <dd className="col-sm-8">{budget.hotelNight ?? '—'}</dd>
-                <dt className="col-sm-4 text-muted">Documentos</dt>
-                <dd className="col-sm-8">{budget.documentsNum ?? budget.documents?.length ?? 0}</dd>
-                <dt className="col-sm-4 text-muted">Notas</dt>
-                <dd className="col-sm-8">{budget.notesCount ?? budget.notes?.length ?? 0}</dd>
+                <dd className="col-sm-8">{deal.fundae ?? '—'}</dd>
+                <dt className="col-sm-4 text-muted">Hotel / pernocta</dt>
+                <dd className="col-sm-8">{deal.hotelNight ?? '—'}</dd>
               </dl>
             </section>
-            <section>
-              <h6 className="text-uppercase text-muted fw-semibold small">Productos extra</h6>
-              {Array.isArray(budget.prodExtraNames) && budget.prodExtraNames.length ? (
-                <div className="d-flex flex-wrap gap-2">
-                  {budget.prodExtraNames.map((extra) => (
-                    <Badge bg="light" text="dark" key={extra} className="px-3 py-2 rounded-pill border">
-                      {extra}
-                    </Badge>
-                  ))}
-                </div>
-              ) : (
-                <p className="mb-0 text-muted">Sin productos extra asociados.</p>
-              )}
-            </section>
+
             <section>
               <h6 className="text-uppercase text-muted fw-semibold small">Documentos</h6>
-              {budget.documents && budget.documents.length ? (
+              {documentEntries.length ? (
                 <ul className="mb-0 small">
-                  {budget.documents.map((doc) => (
-                    <li key={doc}>{doc}</li>
+                  {documentEntries.map((document, index) => (
+                    <li key={`${document.title}-${index}`}>
+                      {document.url ? (
+                        <a href={document.url} target="_blank" rel="noreferrer">
+                          {document.title}
+                        </a>
+                      ) : (
+                        document.title
+                      )}
+                    </li>
                   ))}
                 </ul>
               ) : (
                 <p className="mb-0 text-muted">Aún no hay documentos asociados.</p>
               )}
             </section>
+
             <section>
               <h6 className="text-uppercase text-muted fw-semibold small">Notas</h6>
-              {budget.notes && budget.notes.length ? (
+              {notes.length ? (
                 <ul className="mb-0 small">
-                  {budget.notes.map((note, index) => (
+                  {notes.map((note, index) => (
                     <li key={`${note}-${index}`}>{note}</li>
                   ))}
                 </ul>
@@ -99,21 +181,42 @@ export function BudgetDetailModal({ budget, onClose }: BudgetDetailModalProps) {
                 <p className="mb-0 text-muted">Aún no hay notas asociadas.</p>
               )}
             </section>
+
+            <section>
+              <h6 className="text-uppercase text-muted fw-semibold small">Participantes</h6>
+              {participants.length ? (
+                <ul className="mb-0 small">
+                  {participants.map((participant, index) => (
+                    <li key={`${participant.personId}-${index}`}>
+                      <span className="fw-semibold">{participant.firstName} {participant.lastName}</span>
+                      {participant.role ? ` · ${participant.role}` : ''}
+                      {participant.email ? ` · ${participant.email}` : ''}
+                      {participant.phone ? ` · ${participant.phone}` : ''}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="mb-0 text-muted">No hay participantes registrados.</p>
+              )}
+            </section>
+
             <section>
               <h6 className="text-uppercase text-muted fw-semibold small">Trazabilidad</h6>
               <dl className="row mb-0 small">
                 <dt className="col-sm-4 text-muted">Deal ID</dt>
-                <dd className="col-sm-8">{budget.dealId}</dd>
+                <dd className="col-sm-8">{deal.dealId}</dd>
                 <dt className="col-sm-4 text-muted">Organización ID</dt>
-                <dd className="col-sm-8">{budget.dealOrgId}</dd>
+                <dd className="col-sm-8">{deal.dealOrgId}</dd>
                 <dt className="col-sm-4 text-muted">Creado</dt>
-                <dd className="col-sm-8">{budget.createdAt ? new Date(budget.createdAt).toLocaleString() : '—'}</dd>
+                <dd className="col-sm-8">{formatDate(deal.createdAt)}</dd>
                 <dt className="col-sm-4 text-muted">Actualizado</dt>
-                <dd className="col-sm-8">{budget.updatedAt ? new Date(budget.updatedAt).toLocaleString() : '—'}</dd>
+                <dd className="col-sm-8">{formatDate(deal.updatedAt)}</dd>
               </dl>
             </section>
           </div>
-        ) : null}
+        ) : (
+          <p className="mb-0 text-muted">Selecciona un presupuesto para ver su detalle.</p>
+        )}
       </Modal.Body>
     </Modal>
   );

--- a/frontend/src/types/deal.ts
+++ b/frontend/src/types/deal.ts
@@ -5,10 +5,22 @@ export interface TrainingProduct {
   quantity: number;
 }
 
+export interface DealParticipant {
+  personId: number | null;
+  firstName: string | null;
+  lastName: string | null;
+  email: string | null;
+  phone: string | null;
+  role: string | null;
+}
+
 export interface DealSummary {
   dealId: number;
   dealOrgId: number;
   organizationName: string;
+  organizationCif?: string | null;
+  organizationPhone?: string | null;
+  organizationAddress?: string | null;
   title: string;
   clientName: string;
   sede: string;
@@ -25,8 +37,10 @@ export interface DealSummary {
   documentsNum?: number;
   documentsId?: number[];
   documents?: string[];
+  documentsUrls?: (string | null)[];
   notesCount?: number;
   notes?: string[];
+  participants?: DealParticipant[];
   createdAt?: string;
   updatedAt?: string;
 }

--- a/netlify/functions/_shared/dealPayload.js
+++ b/netlify/functions/_shared/dealPayload.js
@@ -1,0 +1,75 @@
+function sanitizeHtml(html) {
+  if (!html) return null;
+  const text = String(html)
+    .replace(/<br\s*\/?>(\r?\n)?/gi, '\n')
+    .replace(/<li[^>]*>/gi, '• ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return text || null;
+}
+
+function normalizeJsonArray(value) {
+  if (!value) return [];
+  return Array.isArray(value) ? value : [];
+}
+
+function buildDealPayloadFromRecord(record) {
+  if (!record) return null;
+
+  const training = normalizeJsonArray(record.training);
+  const prodExtra = normalizeJsonArray(record.prodExtra);
+  const documents = Array.isArray(record.documents) ? record.documents : [];
+  const notes = Array.isArray(record.notes) ? record.notes : [];
+  const participants = Array.isArray(record.participants) ? record.participants : [];
+
+  const trainingNames = training
+    .map((product) => (product && typeof product.name === 'string' ? product.name : null))
+    .filter(Boolean);
+  const extraNames = prodExtra
+    .map((product) => (product && typeof product.name === 'string' ? product.name : null))
+    .filter(Boolean);
+
+  return {
+    deal_id: record.id,
+    deal_org_id: record.organizationId,
+    organization_name: record.organization?.name ?? 'Organización sin nombre',
+    organization_cif: record.organization?.cif ?? null,
+    organization_phone: record.organization?.phone ?? null,
+    organization_address: record.organization?.address ?? null,
+    title: record.title,
+    training_type: record.trainingType ?? null,
+    training,
+    training_names: trainingNames,
+    hours: record.hours,
+    deal_direction: record.direction ?? null,
+    sede: record.sede ?? null,
+    caes: record.caes ?? null,
+    fundae: record.fundae ?? null,
+    hotel_night: record.hotelNight ?? null,
+    prod_extra: prodExtra,
+    prod_extra_names: extraNames,
+    documents_num: record.documentsNum ?? documents.length,
+    documents_id: documents.map((doc) => doc.id),
+    documents: documents.map((doc) => doc.title ?? doc.url ?? `Documento ${doc.id}`),
+    documents_urls: documents.map((doc) => doc.url ?? null),
+    notes_count: record.notesNum ?? notes.length,
+    notes: notes.map((note) => sanitizeHtml(note.comment) ?? note.comment ?? ''),
+    created_at: record.createdAt?.toISOString?.() ?? record.createdAt,
+    updated_at: record.updatedAt?.toISOString?.() ?? record.updatedAt,
+    persons: participants.map((participant) => ({
+      person_id: participant.personId ?? participant.person_id ?? null,
+      role: participant.role ?? null,
+      first_name: participant.person?.firstName ?? participant.first_name ?? null,
+      last_name: participant.person?.lastName ?? participant.last_name ?? null,
+      email: participant.person?.email ?? participant.email ?? null,
+      phone: participant.person?.phone ?? participant.phone ?? null
+    }))
+  };
+}
+
+module.exports = {
+  sanitizeHtml,
+  normalizeJsonArray,
+  buildDealPayloadFromRecord
+};

--- a/netlify/functions/_shared/prisma.js
+++ b/netlify/functions/_shared/prisma.js
@@ -1,0 +1,12 @@
+const { PrismaClient } = require('@prisma/client');
+
+let prisma;
+
+function getPrisma() {
+  if (!prisma) {
+    prisma = new PrismaClient();
+  }
+  return prisma;
+}
+
+module.exports = { getPrisma };

--- a/netlify/functions/_shared/response.js
+++ b/netlify/functions/_shared/response.js
@@ -1,0 +1,49 @@
+const COMMON_HEADERS = {
+  'Content-Type': 'application/json; charset=utf-8',
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization'
+};
+
+function jsonResponse(statusCode, body) {
+  return {
+    statusCode,
+    headers: COMMON_HEADERS,
+    body: JSON.stringify(body)
+  };
+}
+
+function successResponse(body = {}, statusCode = 200) {
+  return jsonResponse(statusCode, { ok: true, ...body });
+}
+
+function errorResponse({
+  statusCode = 500,
+  errorCode = 'UNEXPECTED_ERROR',
+  message = 'Error inesperado',
+  requestId,
+  details
+}) {
+  const payload = {
+    ok: false,
+    error_code: errorCode,
+    message
+  };
+
+  if (requestId) {
+    payload.requestId = requestId;
+  }
+
+  if (details !== undefined) {
+    payload.details = details;
+  }
+
+  return jsonResponse(statusCode, payload);
+}
+
+module.exports = {
+  COMMON_HEADERS,
+  jsonResponse,
+  successResponse,
+  errorResponse
+};


### PR DESCRIPTION
## Summary
- disable automatic refetching for the budgets list, add toast messaging, and prevent double imports while keeping a manual refresh flow
- limit the budgets table to the required four columns and load the modal with data fetched from the new detail endpoint
- expose a structured deal detail route and improve import error handling with shared response helpers on the Netlify functions

## Testing
- npm run build:frontend

------
https://chatgpt.com/codex/tasks/task_e_68daf42352b083288eb71c8f885c6bdd