### PR TITLE
Normalize budget summary mapping and import handling

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -50,8 +50,13 @@ export default function App() {
   const importMutation = useMutation({
     mutationFn: (dealId: string) => importDeal(dealId),
     onSuccess: (budget) => {
-      setSelectedBudgetSummary(budget);
-      setSelectedBudgetId(budget.dealId);
+      if (budget) {
+        setSelectedBudgetSummary(budget);
+        setSelectedBudgetId(budget.dealId);
+      } else {
+        setSelectedBudgetSummary(null);
+        setSelectedBudgetId(null);
+      }
       pushToast({ variant: 'success', message: 'Presupuesto importado' });
       setShowImportModal(false);
       queryClient.invalidateQueries({ queryKey: ['deals', 'noSessions'] });


### PR DESCRIPTION
## Summary
- normalize the deal list and detail client mappers so the budgets table receives populated titles, clients, and IDs
- return a summary after importing a deal and guard the mutation success handler against missing data so the modal can open reliably

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68dbde8a92a48328b71af3696755e86b