### PR TITLE
Fix budget list and detail modal data rendering

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,7 +18,7 @@ type ToastMessage = {
 
 export default function App() {
   const [showImportModal, setShowImportModal] = useState(false);
-  const [selectedBudgetId, setSelectedBudgetId] = useState<number | null>(null);
+  const [selectedBudgetId, setSelectedBudgetId] = useState<string | null>(null);
   const [selectedBudgetSummary, setSelectedBudgetSummary] = useState<DealSummary | null>(null);
   const [activeTab, setActiveTab] = useState('Presupuestos');
   const [toasts, setToasts] = useState<ToastMessage[]>([]);

--- a/frontend/src/features/presupuestos/BudgetTable.tsx
+++ b/frontend/src/features/presupuestos/BudgetTable.tsx
@@ -95,15 +95,25 @@ export function BudgetTable({ budgets, isLoading, isFetching, error, onRetry, on
           </tr>
         </thead>
         <tbody>
-          {budgets.map((budget) => {
+          {budgets.map((budget, index) => {
             const productInfo = getProductLabel(budget);
-            const presupuestoLabel = budget.title || `Presupuesto #${budget.dealId}`;
+            const presupuestoLabel =
+              budget.dealId ||
+              (budget.dealNumericId != null ? String(budget.dealNumericId) : budget.title || '—');
+            const presupuestoTitle = budget.title && budget.title !== presupuestoLabel ? budget.title : undefined;
             const sedeLabel = budget.sede && budget.sede.trim() ? budget.sede : '—';
+            const clientLabel = budget.clientName || budget.organizationName;
 
             return (
-              <tr key={budget.dealId} role="button" onClick={() => onSelect(budget)}>
-                <td className="fw-semibold">{presupuestoLabel}</td>
-                <td>{budget.organizationName}</td>
+              <tr
+                key={budget.dealId || presupuestoLabel || presupuestoTitle || `${budget.organizationName}-${index}`}
+                role="button"
+                onClick={() => onSelect(budget)}
+              >
+                <td className="fw-semibold" title={presupuestoTitle}>
+                  {presupuestoLabel}
+                </td>
+                <td>{clientLabel}</td>
                 <td>{sedeLabel}</td>
                 <td title={productInfo.title}>{productInfo.label}</td>
               </tr>

--- a/frontend/src/features/presupuestos/api.ts
+++ b/frontend/src/features/presupuestos/api.ts
@@ -44,11 +44,22 @@ function normalizeTraining(raw: unknown): { training?: DealSummary['training']; 
 }
 
 function normalizeDealSummary(row: Json): DealSummary {
-  const dealId = toNumber(row?.deal_id ?? row?.dealId ?? row?.id)
+  const rawDealId = row?.deal_id ?? row?.dealId ?? row?.id
+  const dealNumericId = toNumber(rawDealId)
+  const dealIdString = toStringValue(rawDealId) ?? (rawDealId != null ? String(rawDealId) : '')
   const dealOrgId = toNumber(row?.org_id ?? row?.deal_org_id ?? row?.organizationId ?? row?.orgId)
+  const explicitTitle = toStringValue(row?.title ?? row?.deal_title)
+  const presupuestoLabel = toStringValue(row?.presupuesto ?? row?.budget)
+  const resolvedDealId =
+    dealIdString || presupuestoLabel || (dealNumericId != null ? String(dealNumericId) : '')
   const title =
-    toStringValue(row?.title ?? row?.deal_title ?? row?.presupuesto ?? row?.budget) ??
-    (dealId != null ? `Presupuesto #${dealId}` : 'Presupuesto')
+    explicitTitle ??
+    presupuestoLabel ??
+    (resolvedDealId
+      ? `Presupuesto #${resolvedDealId}`
+      : dealNumericId != null
+        ? `Presupuesto #${dealNumericId}`
+        : 'Presupuesto')
 
   const organizationName =
     toStringValue(
@@ -66,17 +77,23 @@ function normalizeDealSummary(row: Json): DealSummary {
   )
 
   const summary: DealSummary = {
-    dealId: dealId ?? Number(row?.deal_id ?? row?.dealId ?? row?.id ?? 0),
-    dealOrgId: dealOrgId ?? Number(row?.org_id ?? row?.deal_org_id ?? row?.organizationId ?? 0),
+    dealId: resolvedDealId,
+    dealNumericId: dealNumericId ?? toNumber(resolvedDealId),
+    dealOrgId:
+      dealOrgId ??
+      toNumber(row?.deal_org_id ?? row?.organizationId ?? row?.orgId ?? null) ??
+      null,
     organizationName,
     clientName: toStringValue(row?.clientName ?? row?.cliente) ?? organizationName,
     title,
     sede,
     trainingType: toStringValue(row?.trainingType ?? row?.training_type ?? row?.pipeline) ?? undefined,
     hours: toNumber(row?.hours) ?? undefined,
+    dealDirection: toStringValue(row?.deal_direction ?? row?.dealDirection ?? row?.direction) ?? undefined,
     caes: toStringValue(row?.caes ?? row?.CAES) ?? undefined,
     fundae: toStringValue(row?.fundae ?? row?.FUNDAE) ?? undefined,
     hotelNight: toStringValue(row?.hotelNight ?? row?.Hotel_Night) ?? undefined,
+    alumnos: toNumber(row?.alumnos) ?? undefined,
     documentsNum: toNumber(row?.documentsNum ?? row?.documents_num) ?? undefined,
     notesCount: toNumber(row?.notesCount ?? row?.notes_num) ?? undefined,
     createdAt: toStringValue(row?.createdAt ?? row?.created_at) ?? undefined,

--- a/frontend/src/types/deal.ts
+++ b/frontend/src/types/deal.ts
@@ -15,8 +15,15 @@ export interface DealParticipant {
 }
 
 export interface DealSummary {
-  dealId: number;
-  dealOrgId: number;
+  /**
+   * Identificador externo del presupuesto. Se mantiene como string para preservar formatos no numéricos.
+   */
+  dealId: string;
+  /**
+   * Identificador numérico (si existe) del presupuesto. Útil para compatibilidad con APIs antiguas.
+   */
+  dealNumericId?: number | null;
+  dealOrgId: number | null;
   organizationName: string;
   organizationCif?: string | null;
   organizationPhone?: string | null;
@@ -32,6 +39,7 @@ export interface DealSummary {
   caes?: string | null;
   fundae?: string | null;
   hotelNight?: string | null;
+  alumnos?: number | null;
   prodExtra?: TrainingProduct[];
   prodExtraNames?: string[];
   documentsNum?: number;

--- a/netlify/functions/deals.ts
+++ b/netlify/functions/deals.ts
@@ -5,8 +5,8 @@ const { getPrisma } = require('./_shared/prisma');
 const EDITABLE_FIELDS = new Set(['sede', 'hours', 'deal_direction', 'CAES', 'FUNDAE', 'Hotel_Night', 'alumnos']);
 
 function parsePathId(path) {
-  const m = path.match(/\/\.netlify\/functions\/deals\/(\d+)/);
-  return m ? Number(m[1]) : null;
+  const m = path.match(/\/\.netlify\/functions\/deals\/([^/]+)/);
+  return m ? decodeURIComponent(m[1]) : null;
 }
 
 exports.handler = async (event) => {
@@ -117,7 +117,9 @@ exports.handler = async (event) => {
 
       const rows = deals.map((d) => ({
         deal_id: d.id,
-        presupuesto: d.title || String(d.id),
+        presupuesto: d.id != null ? String(d.id) : '',
+        title: d.title || '',
+        deal_title: d.title || '',
         cliente: d.organization?.name || '',
         sede: d.sede || '',
         producto: d.training || ''


### PR DESCRIPTION
## Summary
- normalise deal summaries to keep the original budget id, expose additional metadata and update the table to display the correct presupuesto number alongside client, sede and product data
- enhance the budget detail modal by showing summary information up-front, falling back to list data when the full detail is unavailable and keeping field state initialised
- update the Netlify deals endpoint to expose the title separately from the presupuesto id and accept non-numeric identifiers

## Testing
- npm run build:frontend *(fails: 403 Forbidden fetching caniuse-lite)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe47014748328abf6e1457c1d7b43