### PR TITLE
feat: show detailed budget columns

### DIFF
--- a/frontend/src/features/presupuestos/BudgetTable.tsx
+++ b/frontend/src/features/presupuestos/BudgetTable.tsx
@@ -89,9 +89,10 @@ export function BudgetTable({ budgets, isLoading, isFetching, error, onRetry, on
         <thead>
           <tr>
             <th scope="col">Presupuesto</th>
+            <th scope="col">Título</th>
             <th scope="col">Cliente</th>
             <th scope="col">Sede</th>
-            <th scope="col">Producto</th>
+            <th scope="col">Formación</th>
           </tr>
         </thead>
         <tbody>
@@ -102,7 +103,11 @@ export function BudgetTable({ budgets, isLoading, isFetching, error, onRetry, on
               (budget.dealNumericId != null ? String(budget.dealNumericId) : budget.title || '—');
             const presupuestoTitle = budget.title && budget.title !== presupuestoLabel ? budget.title : undefined;
             const sedeLabel = budget.sede && budget.sede.trim() ? budget.sede : '—';
-            const clientLabel = budget.clientName || budget.organizationName;
+            const clientLabel =
+              (budget.clientName && budget.clientName.trim()) ||
+              (budget.organizationName && budget.organizationName.trim()) ||
+              '—';
+            const titleLabel = budget.title && budget.title.trim() ? budget.title : '—';
 
             return (
               <tr
@@ -113,6 +118,7 @@ export function BudgetTable({ budgets, isLoading, isFetching, error, onRetry, on
                 <td className="fw-semibold" title={presupuestoTitle}>
                   {presupuestoLabel}
                 </td>
+                <td title={budget.title}>{titleLabel}</td>
                 <td>{clientLabel}</td>
                 <td>{sedeLabel}</td>
                 <td title={productInfo.title}>{productInfo.label}</td>

--- a/frontend/src/features/presupuestos/api.ts
+++ b/frontend/src/features/presupuestos/api.ts
@@ -71,7 +71,10 @@ function normalizeDealSummary(row: Json): DealSummary {
         row?.organization?.name
     ) ?? ''
 
-  const sede = toStringValue(row?.sede ?? row?.site ?? row?.location) ?? ''
+  const sede =
+    toStringValue(
+      row?.['676d6bd51e52999c582c01f67c99a35ed30bf6ae'] ?? row?.sede ?? row?.site ?? row?.location
+    ) ?? ''
   const trainingInfo = normalizeTraining(
     row?.training ?? row?.trainingNames ?? row?.training_names ?? row?.producto ?? row?.product
   )


### PR DESCRIPTION
## Summary
- display the deal title and renamed Formación column in the budgets table
- normalize Sede values using the custom field identifier from the API response

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68dbeefc40488328bcc98640aa631895