### PR TITLE
Remove budgets refresh button

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -73,7 +73,6 @@ export default function App() {
   const secondaryTabs = useMemo(() => NAVIGATION_ITEMS.filter((item) => item !== 'Presupuestos'), []);
   const budgets = budgetsQuery.data ?? [];
   const isRefreshing = budgetsQuery.isFetching && !budgetsQuery.isLoading;
-  const refreshDisabled = budgetsQuery.isLoading || isRefreshing;
 
   const handleSelectBudget = useCallback((budget: DealSummary) => {
     setSelectedBudgetSummary(budget);
@@ -127,14 +126,6 @@ export default function App() {
                   {(importMutation.isPending || isRefreshing) && (
                     <Spinner animation="border" role="status" size="sm" />
                   )}
-                  <Button
-                    variant="outline-secondary"
-                    size="lg"
-                    onClick={() => queryClient.invalidateQueries({ queryKey: ['deals', 'noSessions'] })}
-                    disabled={refreshDisabled}
-                  >
-                    Refrescar
-                  </Button>
                   <Button size="lg" onClick={() => setShowImportModal(true)}>
                     Importar presupuesto
                   </Button>


### PR DESCRIPTION
## Summary
- remove the manual refresh button from the budgets header
- clean up the unused refresh state flag

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68dbf7e5114883288b96639b7cfda0e5