### PR TITLE
Remove budgets refresh button

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -73,8 +73,6 @@ export default function App() {
   const secondaryTabs = useMemo(() => NAVIGATION_ITEMS.filter((item) => item !== 'Presupuestos'), []);
   const budgets = budgetsQuery.data ?? [];
   const isRefreshing = budgetsQuery.isFetching && !budgetsQuery.isLoading;
-  const refreshDisabled = budgetsQuery.isLoading || isRefreshing;
-
   const handleSelectBudget = useCallback((budget: DealSummary) => {
     setSelectedBudgetSummary(budget);
     setSelectedBudgetId(budget.dealId);
@@ -127,14 +125,6 @@ export default function App() {
                   {(importMutation.isPending || isRefreshing) && (
                     <Spinner animation="border" role="status" size="sm" />
                   )}
-                  <Button
-                    variant="outline-secondary"
-                    size="lg"
-                    onClick={() => queryClient.invalidateQueries({ queryKey: ['deals', 'noSessions'] })}
-                    disabled={refreshDisabled}
-                  >
-                    Refrescar
-                  </Button>
                   <Button size="lg" onClick={() => setShowImportModal(true)}>
                     Importar presupuesto
                   </Button>

--- a/public/js/presupuestos.js
+++ b/public/js/presupuestos.js
@@ -122,15 +122,9 @@ async function importDeal() {
 }
 
 function wireUI() {
-  const refreshBtn = document.getElementById('btnRefresh');
   const openImportBtn = document.getElementById('btnOpenImportModal');
   const confirmImportBtn = document.getElementById('btnConfirmImport');
   const input = document.getElementById('importDealId');
-
-  refreshBtn?.addEventListener('click', (event) => {
-    event.preventDefault();
-    loadDeals();
-  });
 
   openImportBtn?.addEventListener('click', (event) => {
     event.preventDefault();

--- a/public/presupuestos.html
+++ b/public/presupuestos.html
@@ -49,7 +49,6 @@
         <p class="subtitle mb-0">Sube tu presupuesto y planifica</p>
       </div>
       <div class="d-flex gap-2">
-        <button id="btnRefresh" class="btn btn-outline-secondary">Refrescar</button>
         <button id="btnOpenImportModal" class="btn btn-danger">Importar presupuesto</button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- remove the manual refresh button from the public budgets page and its event handler
- simplify the React budgets view by relying on automatic refetches after imports instead of a manual refresh action

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcfa1b85208328afb24714d499deab