### PR TITLE
fix: update Presupuestos listing and detail bindings

### DIFF
--- a/frontend/src/types/deal.ts
+++ b/frontend/src/types/deal.ts
@@ -97,3 +97,28 @@ export interface DealDetail {
   documents?: DealDocument[];
   comments?: DealComment[];
 }
+
+export interface DealDetailViewNote {
+  id?: string | null;
+  content: string;
+  author?: string | null;
+}
+
+export interface DealDetailViewModel {
+  dealId: string;
+  title: string | null;
+  organizationName: string | null;
+  clientName: string | null;
+  pipelineLabel: string | null;
+  trainingAddress: string | null;
+  productName: string | null;
+  hours: number | null;
+  alumnos: number | null;
+  sedeLabel: string | null;
+  caesLabel: string | null;
+  fundaeLabel: string | null;
+  hotelLabel: string | null;
+  extras: unknown;
+  products: DealProduct[];
+  notes: DealDetailViewNote[];
+}


### PR DESCRIPTION
## Summary
- add a typed deal detail view model and update adapters to normalize new label fields
- guard the deal detail query and compose a merged view model for the Presupuestos modal
- rebind Presupuestos listing/detail UI to sede_label and other migrated columns while formatting empty values

## Testing
- npm run build:frontend

------
https://chatgpt.com/codex/tasks/task_e_68dcfa689ec08328bc5be974ce007953