### PR TITLE
Reordenar columnas de la tabla de presupuestos

### DIFF
--- a/frontend/src/features/presupuestos/BudgetTable.tsx
+++ b/frontend/src/features/presupuestos/BudgetTable.tsx
@@ -89,10 +89,10 @@ export function BudgetTable({ budgets, isLoading, isFetching, error, onRetry, on
         <thead>
           <tr>
             <th scope="col">Presupuesto</th>
-            <th scope="col">Título</th>
-            <th scope="col">Sede</th>
             <th scope="col">Empresa</th>
+            <th scope="col">Título</th>
             <th scope="col">Formación</th>
+            <th scope="col">Sede</th>
           </tr>
         </thead>
         <tbody>
@@ -122,10 +122,10 @@ export function BudgetTable({ budgets, isLoading, isFetching, error, onRetry, on
                 <td className="fw-semibold" title={presupuestoTitle}>
                   {presupuestoLabel}
                 </td>
-                <td title={budget.title}>{titleLabel}</td>
-                <td>{sedeLabel}</td>
                 <td>{organizationLabel}</td>
+                <td title={budget.title}>{titleLabel}</td>
                 <td title={productInfo.title}>{productInfo.label}</td>
+                <td>{sedeLabel}</td>
               </tr>
             );
           })}


### PR DESCRIPTION
## Summary
- actualizar el encabezado de la tabla de presupuestos para mostrar el orden Presupuesto, Empresa, Título, Formación y Sede
- reordenar las celdas de datos para que coincidan con el nuevo orden y mantengan los títulos emergentes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de33b470708328b2b37aa04ee655d3