### PR TITLE
Remove fallback notice from budgets table

### DIFF
--- a/frontend/src/features/presupuestos/BudgetTable.tsx
+++ b/frontend/src/features/presupuestos/BudgetTable.tsx
@@ -200,11 +200,6 @@ export function BudgetTable({
           <span>Actualizando listado…</span>
         </div>
       )}
-      {fallbackBudgets && (
-        <div className="px-3 py-2 border-bottom small text-muted">
-          Mostrando datos directamente del servidor (respaldo).
-        </div>
-      )}
       <Table hover className="mb-0 align-middle">
         <thead>
           <tr>


### PR DESCRIPTION
## Summary
- remove the fallback data notice from the budgets table to declutter the UI

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfd1890a5c83288f4b9a6a6b5aaaf1