### PR TITLE
Map deal sede values to branded aliases

### DIFF
--- a/frontend/src/features/presupuestos/BudgetDetailModal.tsx
+++ b/frontend/src/features/presupuestos/BudgetDetailModal.tsx
@@ -10,6 +10,7 @@ import {
   deleteDocument,
   buildDealDetailViewModel
 } from './api';
+import { formatSedeLabel } from './formatSedeLabel';
 import type { DealEditablePatch } from './api';
 import type { DealDetail, DealDetailViewModel, DealSummary } from '../../types/deal';
 
@@ -280,7 +281,10 @@ export function BudgetDetailModal({ dealId, summary, onClose }: Props) {
             <Row className="g-3">
               <Col md={4}>
                 <Form.Label>Sede</Form.Label>
-                <Form.Control value={form.sede_label} onChange={(e) => updateForm('sede_label', e.target.value)} />
+                <Form.Control
+                  value={formatSedeLabel(form.sede_label) ?? ''}
+                  onChange={(e) => updateForm('sede_label', e.target.value)}
+                />
               </Col>
               <Col md={2}>
                 <Form.Label>Alumnos</Form.Label>

--- a/frontend/src/features/presupuestos/BudgetTable.tsx
+++ b/frontend/src/features/presupuestos/BudgetTable.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { Alert, Button, Spinner, Table } from 'react-bootstrap';
 import type { DealSummary } from '../../types/deal';
 import { fetchDealsWithoutSessions } from './api'; // ← usar API común
+import { formatSedeLabel } from './formatSedeLabel';
 
 interface BudgetTableProps {
   budgets: DealSummary[];
@@ -214,7 +215,7 @@ export function BudgetTable({
             const presupuestoTitle = budget.title && budget.title !== presupuestoLabel ? budget.title : undefined;
             const organizationLabel = safeTrim(budget.organization?.name ?? '') ?? '—';
             const titleLabel = safeTrim(budget.title ?? '') ?? '—';
-            const sedeLabel = safeTrim(budget.sede_label ?? '') ?? '—';
+            const sedeLabel = safeTrim(formatSedeLabel(budget.sede_label) ?? '') ?? '—';
 
             const rowKey = id ?? `${organizationLabel}-${titleLabel}-${index}`;
 

--- a/frontend/src/features/presupuestos/formatSedeLabel.ts
+++ b/frontend/src/features/presupuestos/formatSedeLabel.ts
@@ -1,0 +1,13 @@
+const SEDE_ALIASES: Record<string, string> = {
+  'c/ moratín, 100, 08206 sabadell, barcelona': 'GEP Sabadell',
+  'c/ primavera, 1, 28500, arganda del rey, madrid': 'GEP Arganda',
+  'in company - unidad móvil': 'In Company'
+};
+
+export function formatSedeLabel(value: string | null | undefined): string | null {
+  if (value == null) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const alias = SEDE_ALIASES[trimmed.toLowerCase()];
+  return alias ?? trimmed;
+}


### PR DESCRIPTION
## Summary
- add a shared formatter that maps known sede addresses to friendly labels
- apply the formatter in the budget table and modal so the new labels appear in both views

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e62350b2408328b944e20b82f88ea9