### PR TITLE
Adjust budget detail modal contact info and accordion layout

### DIFF
--- a/frontend/src/features/presupuestos/BudgetDetailModal.tsx
+++ b/frontend/src/features/presupuestos/BudgetDetailModal.tsx
@@ -133,6 +133,8 @@ export function BudgetDetailModal({ dealId, summary, onClose }: Props) {
   const titleDisplay = detailView.title ?? '';
   const organizationDisplay = detailView.organizationName ?? '';
   const clientDisplay = detailView.clientName ?? '';
+  const clientPhoneDisplay = detailView.clientPhone ?? '';
+  const clientEmailDisplay = detailView.clientEmail ?? '';
   const detailProducts = detailView.products;
   const detailNotes = detailView.notes;
   const documents = deal?.documents ?? [];
@@ -178,12 +180,16 @@ export function BudgetDetailModal({ dealId, summary, onClose }: Props) {
     setMapAddress(null);
   };
 
-  const handleAccordionSelect = (eventKey: string | null) => {
+  const handleAccordionSelect = (eventKey: string | string[] | null | undefined) => {
     if (!eventKey) return;
+    const normalizedKey = Array.isArray(eventKey)
+      ? eventKey[eventKey.length - 1]
+      : eventKey;
+    if (!normalizedKey) return;
     setOpenSections((current) =>
-      current.includes(eventKey)
-        ? current.filter((key) => key !== eventKey)
-        : [...current, eventKey]
+      current.includes(normalizedKey)
+        ? current.filter((key) => key !== normalizedKey)
+        : [...current, normalizedKey]
     );
   };
 
@@ -309,16 +315,24 @@ export function BudgetDetailModal({ dealId, summary, onClose }: Props) {
         </Modal.Title>
       </Modal.Header>
       <Modal.Body className="erp-modal-body">
-        {(titleDisplay || clientDisplay || deal) && (
+        {(titleDisplay || clientDisplay || clientPhoneDisplay || clientEmailDisplay || deal) && (
           <div className="erp-summary-card mb-4">
-            <Row className="g-3">
-              <Col md={6}>
+            <Row className="erp-summary-row gy-3 gx-0">
+              <Col md={3}>
                 <Form.Label>Título</Form.Label>
                 <Form.Control value={displayOrDash(titleDisplay)} readOnly />
               </Col>
-              <Col md={6}>
+              <Col md={3}>
                 <Form.Label>Cliente</Form.Label>
                 <Form.Control value={displayOrDash(clientDisplay)} readOnly />
+              </Col>
+              <Col md={3}>
+                <Form.Label>Teléfono</Form.Label>
+                <Form.Control value={displayOrDash(clientPhoneDisplay)} readOnly />
+              </Col>
+              <Col md={3}>
+                <Form.Label>Mail</Form.Label>
+                <Form.Control value={displayOrDash(clientEmailDisplay)} readOnly />
               </Col>
             </Row>
           </div>
@@ -397,15 +411,6 @@ export function BudgetDetailModal({ dealId, summary, onClose }: Props) {
                 <Form.Label>PO</Form.Label>
                 <Form.Control value={displayOrDash(deal.po ?? null)} readOnly />
               </Col>
-              <Col md={2}>
-                <Form.Label>Alumnos</Form.Label>
-                <Form.Control
-                  type="number"
-                  min={0}
-                  value={form.alumnos}
-                  onChange={(e) => updateForm('alumnos', e.target.value)}
-                />
-              </Col>
             </Row>
 
             <hr className="my-4" />
@@ -418,10 +423,9 @@ export function BudgetDetailModal({ dealId, summary, onClose }: Props) {
               <Accordion.Item eventKey="notes">
                 <Accordion.Header>
                   <div className="d-flex justify-content-between align-items-center w-100">
-                    <span>Notas</span>
-                    {detailNotes.length > 0 ? (
-                      <Badge bg="danger">{detailNotes.length}</Badge>
-                    ) : null}
+                    <span className="erp-accordion-title">
+                      Notas{detailNotes.length > 0 ? ` ${detailNotes.length}` : ''}
+                    </span>
                   </div>
                 </Accordion.Header>
                 <Accordion.Body>
@@ -435,7 +439,7 @@ export function BudgetDetailModal({ dealId, summary, onClose }: Props) {
                       ))}
                     </ListGroup>
                   ) : (
-                    <p className="text-muted small mb-0">No hay notas registradas.</p>
+                    <p className="text-muted small mb-0">Sin Notas</p>
                   )}
                 </Accordion.Body>
               </Accordion.Item>
@@ -443,8 +447,9 @@ export function BudgetDetailModal({ dealId, summary, onClose }: Props) {
               <Accordion.Item eventKey="documents">
                 <Accordion.Header>
                   <div className="d-flex justify-content-between align-items-center w-100">
-                    <span>Documentos</span>
-                    {documents.length > 0 ? <Badge bg="danger">{documents.length}</Badge> : null}
+                    <span className="erp-accordion-title">
+                      Documentos{documents.length > 0 ? ` ${documents.length}` : ''}
+                    </span>
                   </div>
                 </Accordion.Header>
                 <Accordion.Body>
@@ -474,7 +479,7 @@ export function BudgetDetailModal({ dealId, summary, onClose }: Props) {
                       ))}
                     </ListGroup>
                   ) : (
-                    <p className="text-muted small mb-0">No hay documentos cargados.</p>
+                    <p className="text-muted small mb-0">Sin documentos</p>
                   )}
                 </Accordion.Body>
               </Accordion.Item>
@@ -482,8 +487,9 @@ export function BudgetDetailModal({ dealId, summary, onClose }: Props) {
               <Accordion.Item eventKey="extra-products">
                 <Accordion.Header>
                   <div className="d-flex justify-content-between align-items-center w-100">
-                    <span>Productos Extra</span>
-                    {extraProducts.length > 0 ? <Badge bg="danger">{extraProducts.length}</Badge> : null}
+                    <span className="erp-accordion-title">
+                      Productos Extra{extraProducts.length > 0 ? ` ${extraProducts.length}` : ''}
+                    </span>
                   </div>
                 </Accordion.Header>
                 <Accordion.Body>
@@ -499,7 +505,7 @@ export function BudgetDetailModal({ dealId, summary, onClose }: Props) {
                       ))}
                     </ListGroup>
                   ) : (
-                    <p className="text-muted small mb-0">No hay productos extra asociados.</p>
+                    <p className="text-muted small mb-0">Sin Extras</p>
                   )}
                 </Accordion.Body>
               </Accordion.Item>

--- a/frontend/src/features/presupuestos/api.ts
+++ b/frontend/src/features/presupuestos/api.ts
@@ -475,7 +475,10 @@ export function buildDealDetailViewModel(
     detail?.organization?.name ?? null,
     summary?.organization?.name ?? null
   );
-  const clientName = buildPersonFullName(detail?.person ?? summary?.person ?? null);
+  const person = detail?.person ?? summary?.person ?? null;
+  const clientName = buildPersonFullName(person ?? null);
+  const clientEmail = pickNonEmptyString(person?.email ?? null);
+  const clientPhone = pickNonEmptyString(person?.phone ?? null);
 
   const pipelineLabel = pickNonEmptyString(
     detail?.pipeline_label ?? null,
@@ -501,6 +504,8 @@ export function buildDealDetailViewModel(
     title: title ?? null,
     organizationName: organizationName ?? null,
     clientName: clientName ?? null,
+    clientEmail: clientEmail ?? null,
+    clientPhone: clientPhone ?? null,
     pipelineLabel: pipelineLabel ?? null,
     trainingAddress: trainingAddress ?? null,
     productName: productName ?? null,

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -61,13 +61,20 @@ body {
 .erp-modal-header {
   background-color: var(--color-red);
   color: #ffffff;
-  padding: 1.5rem 1.5rem 1rem;
+  padding: 1.5rem;
   border-top-left-radius: 18px;
   border-top-right-radius: 18px;
+  display: flex;
+  align-items: center;
 }
 
 .erp-modal-header .modal-title {
   color: inherit;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .erp-modal-header .btn-close {
@@ -104,4 +111,29 @@ body {
 .erp-summary-card .form-label {
   font-weight: 600;
   color: var(--color-gray-medium);
+}
+
+.erp-summary-row > [class*='col-'] {
+  display: flex;
+  flex-direction: column;
+}
+
+.erp-summary-row .form-control[readonly] {
+  background-color: transparent;
+  border: none;
+  padding-left: 0;
+  padding-right: 0;
+  color: var(--color-gray-dark);
+  font-weight: 500;
+  box-shadow: none;
+  cursor: default;
+}
+
+.erp-summary-row .form-label {
+  margin-bottom: 0.25rem;
+}
+
+.erp-accordion-title {
+  font-weight: 600;
+  color: var(--color-gray-dark);
 }

--- a/frontend/src/types/deal.ts
+++ b/frontend/src/types/deal.ts
@@ -134,6 +134,8 @@ export interface DealDetailViewModel {
 
   organizationName: string | null;
   clientName: string | null;
+  clientEmail: string | null;
+  clientPhone: string | null;
 
   pipelineLabel: string | null;    // proviene de pipeline_label
   trainingAddress: string | null;  // proviene de training_address


### PR DESCRIPTION
## Summary
- center the budget detail modal header text and refine the summary row styling
- add phone and mail fields to the summary while removing the alumnos input
- move note/document/extra counters beside their titles and show the required empty state labels

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e63c3548188328b5073c9cd27e226c