### PR TITLE
Fix budget detail modal accordion and header styling

### DIFF
--- a/frontend/src/features/presupuestos/BudgetDetailModal.tsx
+++ b/frontend/src/features/presupuestos/BudgetDetailModal.tsx
@@ -181,15 +181,20 @@ export function BudgetDetailModal({ dealId, summary, onClose }: Props) {
   };
 
   const handleAccordionSelect = (eventKey: string | string[] | null | undefined) => {
-    if (!eventKey) return;
-    const normalizedKey = Array.isArray(eventKey)
-      ? eventKey[eventKey.length - 1]
-      : eventKey;
-    if (!normalizedKey) return;
+    if (eventKey === null || eventKey === undefined) {
+      setOpenSections([]);
+      return;
+    }
+
+    if (Array.isArray(eventKey)) {
+      setOpenSections(eventKey);
+      return;
+    }
+
     setOpenSections((current) =>
-      current.includes(normalizedKey)
-        ? current.filter((key) => key !== normalizedKey)
-        : [...current, normalizedKey]
+      current.includes(eventKey)
+        ? current.filter((key) => key !== eventKey)
+        : [...current, eventKey]
     );
   };
 
@@ -316,7 +321,7 @@ export function BudgetDetailModal({ dealId, summary, onClose }: Props) {
       </Modal.Header>
       <Modal.Body className="erp-modal-body">
         {(titleDisplay || clientDisplay || clientPhoneDisplay || clientEmailDisplay || deal) && (
-          <div className="erp-summary-card mb-4">
+          <div className="mb-4">
             <Row className="erp-summary-row gy-3 gx-0">
               <Col md={3}>
                 <Form.Label>Título</Form.Label>
@@ -424,7 +429,10 @@ export function BudgetDetailModal({ dealId, summary, onClose }: Props) {
                 <Accordion.Header>
                   <div className="d-flex justify-content-between align-items-center w-100">
                     <span className="erp-accordion-title">
-                      Notas{detailNotes.length > 0 ? ` ${detailNotes.length}` : ''}
+                      Notas
+                      {detailNotes.length > 0 ? (
+                        <span className="erp-accordion-count">{detailNotes.length}</span>
+                      ) : null}
                     </span>
                   </div>
                 </Accordion.Header>
@@ -448,7 +456,10 @@ export function BudgetDetailModal({ dealId, summary, onClose }: Props) {
                 <Accordion.Header>
                   <div className="d-flex justify-content-between align-items-center w-100">
                     <span className="erp-accordion-title">
-                      Documentos{documents.length > 0 ? ` ${documents.length}` : ''}
+                      Documentos
+                      {documents.length > 0 ? (
+                        <span className="erp-accordion-count">{documents.length}</span>
+                      ) : null}
                     </span>
                   </div>
                 </Accordion.Header>
@@ -488,7 +499,10 @@ export function BudgetDetailModal({ dealId, summary, onClose }: Props) {
                 <Accordion.Header>
                   <div className="d-flex justify-content-between align-items-center w-100">
                     <span className="erp-accordion-title">
-                      Productos Extra{extraProducts.length > 0 ? ` ${extraProducts.length}` : ''}
+                      Productos Extra
+                      {extraProducts.length > 0 ? (
+                        <span className="erp-accordion-count">{extraProducts.length}</span>
+                      ) : null}
                     </span>
                   </div>
                 </Accordion.Header>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -101,39 +101,42 @@ body {
   border-top: none;
 }
 
-.erp-summary-card {
-  background-color: #ffffff;
-  border: 1px solid var(--color-gray-light);
-  border-radius: 12px;
-  padding: 1.25rem;
-}
-
-.erp-summary-card .form-label {
-  font-weight: 600;
-  color: var(--color-gray-medium);
-}
-
 .erp-summary-row > [class*='col-'] {
   display: flex;
   flex-direction: column;
 }
 
 .erp-summary-row .form-control[readonly] {
-  background-color: transparent;
-  border: none;
-  padding-left: 0;
-  padding-right: 0;
+  background-color: #ffffff;
+  border: 1px solid #ced4da;
   color: var(--color-gray-dark);
   font-weight: 500;
-  box-shadow: none;
   cursor: default;
 }
 
 .erp-summary-row .form-label {
   margin-bottom: 0.25rem;
+  font-weight: 600;
+  color: var(--color-gray-medium);
 }
 
 .erp-accordion-title {
   font-weight: 600;
   color: var(--color-gray-dark);
+}
+
+.erp-accordion-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 0.5rem;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  padding: 0 0.5rem;
+  border-radius: 999px;
+  background-color: var(--color-red);
+  color: #ffffff;
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1;
 }


### PR DESCRIPTION
## Summary
- allow collapsing budget detail accordion sections consistently
- show red pill counters for notes, documents, and extras in the accordion headers
- remove the grouped summary card styling so top fields display with individual borders

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e64123fbf08328ace4ce292630bb8c