### PR TITLE
Adjust spacing for budget summary fields

### DIFF
--- a/frontend/src/features/presupuestos/BudgetDetailModal.tsx
+++ b/frontend/src/features/presupuestos/BudgetDetailModal.tsx
@@ -322,7 +322,7 @@ export function BudgetDetailModal({ dealId, summary, onClose }: Props) {
       <Modal.Body className="erp-modal-body">
         {(titleDisplay || clientDisplay || clientPhoneDisplay || clientEmailDisplay || deal) && (
           <div className="mb-4">
-            <Row className="erp-summary-row gy-3 gx-0">
+            <Row className="erp-summary-row g-3">
               <Col md={3}>
                 <Form.Label>Título</Form.Label>
                 <Form.Control value={displayOrDash(titleDisplay)} readOnly />


### PR DESCRIPTION
## Summary
- update the summary row spacing in the budget detail modal so the first row matches the spacing of subsequent rows

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e644b484708328823ae2018266da9b