### PR TITLE
feat: enhance budget note interactions

### DIFF
--- a/frontend/src/features/presupuestos/api.ts
+++ b/frontend/src/features/presupuestos/api.ts
@@ -437,6 +437,24 @@ export async function updateDealNote(
   return normalizeDealNote(data?.note ?? {});
 }
 
+export async function deleteDealNote(
+  dealId: string,
+  noteId: string,
+  user?: { id: string; name?: string }
+): Promise<void> {
+  const headers: Record<string, string> = {};
+  if (user?.id) headers["X-User-Id"] = user.id;
+  if (user?.name) headers["X-User-Name"] = user.name;
+
+  await request(
+    `/deal_notes/${encodeURIComponent(String(dealId))}/${encodeURIComponent(String(noteId))}`,
+    {
+      method: "DELETE",
+      headers,
+    }
+  );
+}
+
 /* ======================
  * Documentos (S3/PDrive)
  * ====================== */


### PR DESCRIPTION
## Summary
- show existing deal notes ahead of the creation form and surface request errors
- open a modal with the full note content when selecting a note from the list
- allow authors to delete their notes via the API and keep the view model in sync

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e64c289eb08328b7b772e2b6e37033