### PR TITLE
Add update and close controls to budget detail modal

### DIFF
--- a/frontend/src/features/presupuestos/BudgetDetailModal.tsx
+++ b/frontend/src/features/presupuestos/BudgetDetailModal.tsx
@@ -141,6 +141,7 @@ export function BudgetDetailModal({ dealId, summary, onClose }: Props) {
 
   const dirtyDeal = !!initialEditable && !!form && JSON.stringify(initialEditable) !== JSON.stringify(form);
   const isDirty = dirtyDeal;
+  const isRefetching = detailQuery.isRefetching;
 
   if (!dealId) return null;
 
@@ -195,6 +196,16 @@ export function BudgetDetailModal({ dealId, summary, onClose }: Props) {
       }
     } finally {
       setCreatingNote(false);
+    }
+  };
+
+  const handleRefresh = async () => {
+    if (!normalizedDealId) return;
+    const result = await detailQuery.refetch();
+    if (result.error) {
+      const error: any = result.error;
+      const message = typeof error?.message === 'string' ? error.message : 'No se pudo actualizar la información';
+      alert(message);
     }
   };
 
@@ -436,8 +447,8 @@ export function BudgetDetailModal({ dealId, summary, onClose }: Props) {
       centered
       contentClassName="erp-modal-content"
     >
-      <Modal.Header closeButton className="erp-modal-header border-0 pb-0">
-        <Modal.Title as="div">
+      <Modal.Header className="erp-modal-header border-0 pb-0">
+        <Modal.Title as="div" className="erp-modal-header-main">
           <div className="erp-modal-title text-truncate">{modalTitle}</div>
           {presupuestoDisplay ? (
             <div className="erp-modal-subtitle text-truncate">
@@ -445,6 +456,39 @@ export function BudgetDetailModal({ dealId, summary, onClose }: Props) {
             </div>
           ) : null}
         </Modal.Title>
+        <div className="erp-modal-header-actions">
+          <Button
+            variant="light"
+            size="sm"
+            className="erp-modal-action"
+            onClick={handleRefresh}
+            disabled={isLoading || isRefetching}
+          >
+            {isRefetching ? (
+              <>
+                <Spinner
+                  as="span"
+                  animation="border"
+                  size="sm"
+                  role="status"
+                  aria-hidden="true"
+                  className="me-2"
+                />
+                Actualizando...
+              </>
+            ) : (
+              'Actualizar'
+            )}
+          </Button>
+          <Button
+            variant="outline-light"
+            size="sm"
+            className="erp-modal-action"
+            onClick={requestClose}
+          >
+            Cerrar
+          </Button>
+        </div>
       </Modal.Header>
       <Modal.Body className="erp-modal-body">
         {(titleDisplay || clientDisplay || clientPhoneDisplay || clientEmailDisplay || deal) && (

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -66,6 +66,8 @@ body {
   border-top-right-radius: 18px;
   display: flex;
   align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
 }
 
 .erp-modal-header .modal-title {
@@ -75,6 +77,33 @@ body {
   justify-content: center;
   flex: 1 1 auto;
   min-width: 0;
+}
+
+.erp-modal-header-main {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.erp-modal-header-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.erp-modal-action {
+  font-weight: 600;
+}
+
+.erp-modal-header-actions .btn-outline-light {
+  color: #ffffff;
+  border-color: rgba(255, 255, 255, 0.65);
+}
+
+.erp-modal-header-actions .btn-outline-light:hover,
+.erp-modal-header-actions .btn-outline-light:focus {
+  color: var(--color-red);
+  background-color: #ffffff;
+  border-color: #ffffff;
 }
 
 .erp-modal-header .btn-close {


### PR DESCRIPTION
## Summary
- replace the modal close affordance with Update and Close buttons in the budget detail modal header
- add a refresh handler that refetches the deal data while preserving previously added notes and documents
- adjust modal header styling to support the new action buttons

## Testing
- npm --prefix frontend run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e65349118483288797cfb4a49dd55c