### PR TITLE
Adjusta proporciones de los campos de sede y dirección

### DIFF
--- a/frontend/src/features/presupuestos/BudgetDetailModal.tsx
+++ b/frontend/src/features/presupuestos/BudgetDetailModal.tsx
@@ -551,14 +551,14 @@ export function BudgetDetailModal({ dealId, summary, onClose }: Props) {
           <>
             {/* Editables */}
             <Row className="g-3">
-              <Col md={6}>
+              <Col md={4}>
                 <Form.Label>Sede</Form.Label>
                 <Form.Control
                   value={formatSedeLabel(form.sede_label) ?? ''}
                   onChange={(e) => updateForm('sede_label', e.target.value)}
                 />
               </Col>
-              <Col md={6}>
+              <Col md={8}>
                 <Form.Label>Dirección</Form.Label>
                 <div className="d-flex gap-2 align-items-start">
                   <Form.Control


### PR DESCRIPTION
## Summary
- reduce el ancho de la columna del campo Sede en el modal de detalle de presupuesto
- amplía el espacio disponible para el campo Dirección manteniendo el botón de ver mapa

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e657e898f08328b8e70814df20e0da