### PR TITLE
Fix deal re-import to overwrite editable labels

### DIFF
--- a/backend/functions/_shared/mappers.ts
+++ b/backend/functions/_shared/mappers.ts
@@ -208,7 +208,7 @@ export async function mapAndUpsertDealTree({
   });
 
   const keep = <T>(prev: T | null | undefined, incoming: T | null | undefined) =>
-    prev !== null && prev !== undefined ? prev : incoming ?? null;
+    incoming !== null && incoming !== undefined ? incoming : prev ?? null;
 
   // 5) Upsert deal (sin 'hours' en deals)
   const orgIdForDeal = org?.id != null ? String(org.id) : null;


### PR DESCRIPTION
## Summary
- ensure deal re-imports overwrite editable labels with the latest values from Pipedrive

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e6587065b0832885397ba1583dad76