### PR TITLE
feat: allow editing training hours and show comments

### DIFF
--- a/backend/functions/deal_documents.ts
+++ b/backend/functions/deal_documents.ts
@@ -136,7 +136,7 @@ export const handler = async (event: any) => {
         },
       });
 
-      const documents = docsRaw.map((d) => {
+      const documents = docsRaw.map((d: any) => {
         const fromS3 = !isHttpUrl(d.file_url);
         return {
           id: d.id,

--- a/frontend/src/types/deal.ts
+++ b/frontend/src/types/deal.ts
@@ -41,7 +41,7 @@ export interface DealProduct {
   type?: DealProductType;   // enum existente
 
   // NUEVOS (según migración)
-  hours?: number;               // entero, sin “h”; si no viene → 0
+  hours?: number | null;        // entero opcional; si no viene → null
   comments?: string | null;     // comentarios por línea
   typeLabel?: string | null;    // solo para filtros futuros
   categoryLabel?: string | null;


### PR DESCRIPTION
## Summary
- allow editing the hours of each formación in the detail modal and show product comments with a modal preview
- extend the client API to send product hour patches and normalize product comments/hours
- handle product hour/comment updates in the deals function backend

## Testing
- npm run typecheck:functions
- npm run build:frontend

------
https://chatgpt.com/codex/tasks/task_e_68e65d2fb60c83288e0a0dc9f2439fcc