### PR TITLE
Fix dirty state calculation to prevent BudgetDetailModal crash

### DIFF
--- a/frontend/src/features/presupuestos/BudgetDetailModal.tsx
+++ b/frontend/src/features/presupuestos/BudgetDetailModal.tsx
@@ -205,18 +205,6 @@ export function BudgetDetailModal({ dealId, summary, onClose }: Props) {
     };
   }, [deal, summary]);
 
-  const dirtyDeal = !!initialEditable && !!form && JSON.stringify(initialEditable) !== JSON.stringify(form);
-  const isDirty = dirtyDeal || dirtyProducts;
-  const isRefetching = detailQuery.isRefetching || refreshMutation.isPending;
-
-  if (!dealId) return null;
-
-  const presupuestoDisplay = detailView.dealId;
-  const titleDisplay = detailView.title ?? '';
-  const organizationDisplay = detailView.organizationName ?? '';
-  const clientDisplay = detailView.clientName ?? '';
-  const clientPhoneDisplay = detailView.clientPhone ?? '';
-  const clientEmailDisplay = detailView.clientEmail ?? '';
   const detailProducts = detailView.products;
   const detailNotes = detailView.notes;
   const documents = deal?.documents ?? [];
@@ -252,6 +240,19 @@ export function BudgetDetailModal({ dealId, summary, onClose }: Props) {
     () => !areHourMapsEqual(productHours, initialProductHours),
     [productHours, initialProductHours]
   );
+
+  const dirtyDeal = !!initialEditable && !!form && JSON.stringify(initialEditable) !== JSON.stringify(form);
+  const isDirty = dirtyDeal || dirtyProducts;
+  const isRefetching = detailQuery.isRefetching || refreshMutation.isPending;
+
+  if (!dealId) return null;
+
+  const presupuestoDisplay = detailView.dealId;
+  const titleDisplay = detailView.title ?? '';
+  const organizationDisplay = detailView.organizationName ?? '';
+  const clientDisplay = detailView.clientName ?? '';
+  const clientPhoneDisplay = detailView.clientPhone ?? '';
+  const clientEmailDisplay = detailView.clientEmail ?? '';
 
   const extraProducts = detailProducts.filter((product) => {
     const code = product?.code ?? '';


### PR DESCRIPTION
## Summary
- ensure the detail data is prepared before computing training products in the budget detail modal
- compute dirty state flags after product hour memoization to avoid temporal dead zone errors at runtime

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e664d5ba2483288a2efcabd4225d93