### PR TITLE
Fix accordion highlight styling for expanded sections

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -17,11 +17,13 @@ body {
 }
 
 .accordion {
-  --bs-accordion-btn-bg: var(--color-red-muted);
+  --bs-accordion-bg: #ffffff;
+  --bs-accordion-body-bg: var(--color-red-muted);
+  --bs-accordion-btn-bg: #ffffff;
   --bs-accordion-btn-color: var(--color-gray-dark);
   --bs-accordion-active-bg: var(--color-red-muted);
   --bs-accordion-active-color: var(--color-gray-dark);
-  --bs-accordion-border-color: var(--color-red-muted);
+  --bs-accordion-border-color: #dee2e6;
   --bs-accordion-btn-focus-border-color: rgba(232, 71, 77, 0.4);
   --bs-accordion-active-border-color: var(--color-red-muted);
   --bs-accordion-btn-focus-box-shadow: 0 0 0 0.25rem rgba(232, 71, 77, 0.15);


### PR DESCRIPTION
## Summary
- ensure accordion headers use the soft red background only while expanded
- restore neutral borders and collapsed header styling while keeping the body tint for the active section

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e6688a32fc8328b8d6a8c81534021c