### PR TITLE
Fix deal document display and previews

### DIFF
--- a/backend/functions/deal_documents.ts
+++ b/backend/functions/deal_documents.ts
@@ -137,12 +137,13 @@ export const handler = async (event: any) => {
       });
 
       const documents = docsRaw.map((d: any) => {
-        const fromS3 = !isHttpUrl(d.file_url);
+        const isHttp = isHttpUrl(d.file_url);
         return {
           id: d.id,
-          source: fromS3 ? "S3" : "PIPEDRIVE",
+          source: isHttp ? "PIPEDRIVE" : "S3",
           name: d.file_name ?? null,
           mime_type: d.file_type ?? null,
+          url: isHttp ? d.file_url ?? null : null,
           // no tenemos `size` en el esquema → lo omitimos
           created_at: d.created_at,
         };


### PR DESCRIPTION
## Summary
- expose Pipedrive URLs when listing deal documents and normalize stored files in the deals API
- normalize document metadata on the frontend and fetch preview URLs with names and mime types
- update the budget detail modal to show clickable document names with an in-app preview modal and download controls

## Testing
- npm run build:frontend

------
https://chatgpt.com/codex/tasks/task_e_68e66a4187a08328a5e7f18449b23066