### PR TITLE
Add `typecheck:noemit` backend script and expose workspace command

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ Desde raíz:
 - `npm run test --workspace frontend` — tests unitarios/interfaz frontend.
 - `npm run typecheck --workspace frontend` — chequeo de tipos frontend.
 - `npm run typecheck:functions` — chequeo de tipos de funciones backend.
+- `npm run typecheck:functions:noemit` — chequeo backend en modo `--noEmit --pretty false` (incluye `prisma generate` antes de `tsc`).
 - `npm run prisma:format` — formato de esquema Prisma.
 - `npm run prisma:prune` — limpieza de binarios Prisma para CI/Netlify.
 - `npm run netlify:build` — pipeline de build para despliegue.

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,7 @@
     "migrate:deploy": "node ../scripts/prisma-migrate-retry.js",
     "prisma:prune": "node ../scripts/prisma-prune-binaries.mjs || true",
     "typecheck": "npm run generate && tsc -p tsconfig.json",
+    "typecheck:noemit": "npm run generate && tsc --noEmit --pretty false",
     "typecheck:function:daily-availability-slack": "tsc --noEmit --target ES2022 --module commonjs --moduleResolution node --esModuleInterop --skipLibCheck functions/daily-availability-slack.ts",
     "typecheck:function:daily-trainers-slack": "tsc --noEmit --target ES2022 --module commonjs --moduleResolution node --esModuleInterop --skipLibCheck functions/daily-trainers-slack.ts",
     "postinstall": "prisma generate --schema prisma/schema.prisma"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "prisma:format": "backend/node_modules/.bin/prisma format --schema backend/prisma/schema.prisma",
     "prisma:generate": "npm run -w backend generate",
     "typecheck:functions": "npm run -w backend typecheck",
+    "typecheck:functions:noemit": "npm run -w backend typecheck:noemit",
     "typecheck:function:daily-availability-slack": "npm run -w backend typecheck:function:daily-availability-slack",
     "typecheck:function:daily-trainers-slack": "npm run -w backend typecheck:function:daily-trainers-slack"
   },


### PR DESCRIPTION
### Motivation
- Provide a CI/Netlify-friendly TypeScript check for backend/functions that runs `prisma generate` then `tsc --noEmit --pretty false` without emitting artifacts.

### Description
- Add `typecheck:noemit` script to `backend/package.json` that runs `npm run generate && tsc --noEmit --pretty false`.
- Expose the backend script at the monorepo root with `typecheck:functions:noemit` in `package.json` using `npm run -w backend typecheck:noemit`.
- Document the new command in `README.md` under the useful commands list as `npm run typecheck:functions:noemit` and describe its behavior.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d74f0572ec83258516125b2d51f2bd)