### PR TITLE
Automatiza alta de alumnos de Formación Abierta tras webhook

### DIFF
--- a/backend/functions/deals.ts
+++ b/backend/functions/deals.ts
@@ -974,6 +974,7 @@ export async function importDealFromPipedrive(dealIdRaw: any) {
     productsCount: 0,
     notesCount: 0,
     filesCount: 0,
+    notesFetched: false,
   };
   let errorMessage: string | undefined;
 
@@ -1123,6 +1124,7 @@ export async function importDealFromPipedrive(dealIdRaw: any) {
     counters.productsCount = Array.isArray(products) ? products.length : 0;
     counters.notesCount = Array.isArray(notes) ? notes.length : 0;
     counters.filesCount = Array.isArray(files) ? files.length : 0;
+    counters.notesFetched = !notesFetchFailed;
 
     // 2) Mapear + upsert relacional en Neon
     const persistStart = Date.now();

--- a/backend/functions/pipedrive-webhook.ts
+++ b/backend/functions/pipedrive-webhook.ts
@@ -382,14 +382,25 @@ async function refreshDealAfterWebhook(
   await importDealFromPipedrive(dealId);
 
   const pipeline = stored.pipeline_label ?? stored.pipeline_id ?? null;
-  if (isFormacionAbiertaPipeline(pipeline)) {
-    return true;
-  }
+  const isFormacionAbierta = isFormacionAbiertaPipeline(pipeline);
 
-  // Si el pipeline no quedó resuelto aún, reintentamos igualmente una vez más
-  // para capturar notas/alumnos que llegan con retraso desde Pipedrive.
+  // Reintentamos una vez más para capturar notas/alumnos que llegan con retraso desde Pipedrive.
   await new Promise((resolve) => setTimeout(resolve, 3500));
   await importDealFromPipedrive(dealId);
+
+  // En Formación Abierta algunas automatizaciones de Pipedrive tardan más
+  // en crear la nota con el listado de alumnos. Si aún no hay alumnos,
+  // hacemos un último reintento.
+  if (isFormacionAbierta) {
+    const studentsCount = await prisma.alumnos.count({
+      where: { deal_id: dealId },
+    });
+    if (studentsCount === 0) {
+      await new Promise((resolve) => setTimeout(resolve, 5000));
+      await importDealFromPipedrive(dealId);
+    }
+  }
+
   return true;
 }
 


### PR DESCRIPTION
### Motivation
- Evitar tener que abrir manualmente el presupuesto para que se detecten y creen los alumnos listados en las notas de Pipedrive. 
- Detectar y procesar notas que llegan con retraso desde Pipedrive en el pipeline de "Formación Abierta" tras recibir el webhook. 

### Description
- Modifiqué `refreshDealAfterWebhook` para que siempre ejecute un segundo reintento de importación tras ~3.5s en lugar de retornar anticipadamente para FA, garantizando una reimportación adicional. 
- Añadí un tercer reintento condicional específico para Formación Abierta que, si después de los dos intentos no hay alumnos en BD para el deal, espera 5s y vuelve a ejecutar `importDealFromPipedrive`. 
- Añadí `notesFetched` a la telemetría de `importDealFromPipedrive` para diagnosticar si las notas estaban disponibles en el momento de la importación. 
- Corregí el conteo de alumnos usando `prisma.alumnos.count(...)` (en vez de un modelo inexistente) para comprobar si hay alumnos creados para el deal. 

### Testing
- Ejecuté la comprobación de tipos con `npm run -w backend typecheck`; la primera ejecución falló por un acceso a `prisma.students` inexistente y se corrigió reemplazándolo por `prisma.alumnos`, tras lo cual la comprobación de tipos pasó correctamente. 
- No se añadieron tests automatizados nuevos además del `typecheck`, y dicha verificación final resultó en éxito.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d7d948e43483258d42674dbc46666a)