### PR TITLE
Fix WooCommerce order sync: correct unit pricing and draft Holded invoices

### DIFF
--- a/backend/functions/_shared/woocommerce-compras-pipedrive.ts
+++ b/backend/functions/_shared/woocommerce-compras-pipedrive.ts
@@ -38,6 +38,8 @@ type NormalizedWooOrder = {
   variationIdWoo: string | null;
   sku: string | null;
   quantity: number;
+  unitPrice: number;
+  lineSubtotal: number;
   discountPercentageFromPayload: number;
   subtotal: number;
   taxPercentage: number | null;
@@ -447,6 +449,10 @@ function normalizeWooOrder(payloadRoot: JsonObject): NormalizedWooOrder {
     normalizeComparison(discountType) === 'percent' || normalizeComparison(discountType) === 'percentage'
       ? Math.max(0, nominalAmount)
       : 0;
+  const lineSubtotal = readNumber(lineItem.subtotal) ?? readNumber(payload.total) ?? 0;
+  const unitPriceFromPayload = readNumber(lineItem.price);
+  const unitPrice =
+    unitPriceFromPayload ?? (resolvedQuantity > 0 && lineSubtotal > 0 ? lineSubtotal / resolvedQuantity : lineSubtotal);
 
   return {
     orderId,
@@ -472,8 +478,10 @@ function normalizeWooOrder(payloadRoot: JsonObject): NormalizedWooOrder {
     variationIdWoo: readString(lineItem.variation_id),
     sku: readString(lineItem.sku),
     quantity: resolvedQuantity,
+    unitPrice,
+    lineSubtotal,
     discountPercentageFromPayload,
-    subtotal: readNumber(lineItem.subtotal) ?? readNumber(payload.total) ?? 0,
+    subtotal: lineSubtotal,
     taxPercentage,
     rawDate,
     rawLocation,
@@ -891,7 +899,7 @@ function buildAddProductPayload(order: NormalizedWooOrder, productIdPipe: string
 
   return {
     product_id: normalizedProductId,
-    item_price: order.subtotal,
+    item_price: order.unitPrice,
     quantity: order.quantity,
     discount: discountPercentage > 0 ? discountPercentage : undefined,
     discount_type: 'percentage',
@@ -1326,7 +1334,7 @@ async function createAndSendHoldedInvoiceFromWooOrder(params: {
 
   const invoicePayload = {
     date: 'today',
-    approveDoc: true,
+    approveDoc: false,
     contactCode: holdedContact.code || undefined,
     contactId: holdedContact.id,
     invoiceNum: '',
@@ -1341,7 +1349,7 @@ async function createAndSendHoldedInvoiceFromWooOrder(params: {
         name: params.resolvedProduct.productName ?? params.order.productName ?? 'Reserva de formación',
         desc: '',
         units: params.order.quantity,
-        subtotal: params.order.subtotal,
+        subtotal: params.order.unitPrice,
         discount: params.discountPercentage > 0 ? params.discountPercentage : undefined,
         tax: params.order.taxPercentage ?? 21,
       },
@@ -1357,11 +1365,6 @@ async function createAndSendHoldedInvoiceFromWooOrder(params: {
   if (!documentId) {
     throw new Error('Holded no devolvió el identificador de la factura creada.');
   }
-
-  await holdedRequest<any>(`${HOLDED_INVOICES_ENDPOINT}/${encodeURIComponent(documentId)}`, {
-    method: 'PUT',
-    body: JSON.stringify({ paymentMethod: holdedPaymentMethodId }),
-  });
 
   let emailSent = false;
   if (params.order.billingEmail) {
@@ -1488,17 +1491,22 @@ export async function sendWooOrderToPipedrive(params: {
   let invoiceEmailSent = false;
 
   if (isDirectInvoiceOrder(order)) {
-    const holdedInvoice = await createAndSendHoldedInvoiceFromWooOrder({
-      order,
-      resolvedProduct,
-      discountPercentage: classification.discountPercentage,
-    });
-    holdedDocumentId = holdedInvoice.documentId;
-    holdedDocumentType = 'invoice';
-    invoiceEmailSent = holdedInvoice.emailSent;
+    try {
+      const holdedInvoice = await createAndSendHoldedInvoiceFromWooOrder({
+        order,
+        resolvedProduct,
+        discountPercentage: classification.discountPercentage,
+      });
+      holdedDocumentId = holdedInvoice.documentId;
+      holdedDocumentType = 'invoice';
+      invoiceEmailSent = holdedInvoice.emailSent;
 
-    if (!invoiceEmailSent) {
-      warnings.push('La factura se ha creado en Holded, pero no se ha enviado por email porque el pedido no tiene correo de facturación.');
+      if (!invoiceEmailSent) {
+        warnings.push('La factura se ha creado en Holded, pero no se ha enviado por email porque el pedido no tiene correo de facturación.');
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      warnings.push(`No se pudo crear la factura en Holded: ${message}`);
     }
   }
 


### PR DESCRIPTION
### Motivation
- WooCommerce line-items were normalized so `subtotal` was used as the product unit price in Pipedrive, causing doubled totals when quantity > 1.
- Holded API calls attempted to edit invoices after creation which fails for approved documents and produced `Approved documents cannot be edited` errors.
- When Holded creation failed the flow aborted and Pipedrive updates were not completed, leaving incomplete records.

### Description
- Added `unitPrice` and `lineSubtotal` to `NormalizedWooOrder` and compute `unitPrice` from `line_items[].price` or `subtotal / quantity` to preserve the real unit price in normalization (file: `backend/functions/_shared/woocommerce-compras-pipedrive.ts`).
- Use `order.unitPrice` as `item_price` when adding products to Pipedrive deals so Pipedrive receives the actual unit price and correct subtotals.
- Create Holded invoices as drafts by setting `approveDoc: false` and stop making a follow-up PUT edit that caused the approved-document error.
- Wrap Holded invoice creation in a `try/catch` so Holded failures are recorded as warnings and do not prevent completing Pipedrive updates.

### Testing
- Ran a TypeScript compile check on the modified module with `cd backend && npx tsc --noEmit --target ES2022 --module commonjs --moduleResolution node --esModuleInterop --skipLibCheck functions/_shared/woocommerce-compras-pipedrive.ts`, which completed successfully (non-blocking npm env warning observed).
- No additional automated tests were added; changes were limited to the shared integration module and type-checked successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e0ab8ad1588325b1c572302c930e89)