### PR TITLE
Remove payroll expense entries when deleting trainer documents

### DIFF
--- a/backend/functions/trainer_documents.ts
+++ b/backend/functions/trainer_documents.ts
@@ -362,6 +362,89 @@ async function persistPayrollExpense(
   });
 }
 
+async function removePayrollExpenseForDocument(
+  prisma: Pick<ReturnType<typeof getPrisma>, 'office_payrolls'>,
+  userId: string,
+  documentId: string,
+) {
+  const payroll = await prisma.office_payrolls.findFirst({
+    where: {
+      user_id: userId,
+      comment_cost: { contains: `"${documentId}"` },
+    },
+    select: {
+      user_id: true,
+      year: true,
+      month: true,
+      dietas: true,
+      kilometrajes: true,
+      pernocta: true,
+      nocturnidad: true,
+      festivo: true,
+      horas_extras: true,
+      otros_gastos: true,
+      comment_cost: true,
+    },
+  });
+
+  if (!payroll) {
+    return;
+  }
+
+  const commentMap = parseCommentCostMap(payroll.comment_cost);
+  const commentEntry = commentMap[documentId];
+  if (!commentEntry) {
+    return;
+  }
+
+  delete commentMap[documentId];
+
+  const amount = typeof commentEntry.amount === 'number' && Number.isFinite(commentEntry.amount)
+    ? Number(commentEntry.amount.toFixed(2))
+    : 0;
+  const column = resolveExpenseColumn(commentEntry.category);
+
+  const currentValues: Record<PayrollExtraField, number> = {
+    dietas: decimalToNumber(payroll.dietas),
+    kilometrajes: decimalToNumber(payroll.kilometrajes),
+    pernocta: decimalToNumber(payroll.pernocta),
+    nocturnidad: decimalToNumber(payroll.nocturnidad),
+    festivo: decimalToNumber(payroll.festivo),
+    horas_extras: decimalToNumber(payroll.horas_extras),
+    otros_gastos: decimalToNumber(payroll.otros_gastos),
+  };
+
+  if (column && amount > 0) {
+    const nextValue = Number((currentValues[column] - amount).toFixed(2));
+    currentValues[column] = nextValue < 0 ? 0 : nextValue;
+  }
+
+  const nextTotalExtras = Number(
+    PAYROLL_EXTRA_FIELDS.reduce((acc, field) => acc + currentValues[field], 0).toFixed(2),
+  );
+
+  await prisma.office_payrolls.update({
+    where: {
+      user_id_year_month: {
+        user_id: payroll.user_id,
+        year: payroll.year,
+        month: payroll.month,
+      },
+    },
+    data: {
+      dietas: new Prisma.Decimal(currentValues.dietas),
+      kilometrajes: new Prisma.Decimal(currentValues.kilometrajes),
+      pernocta: new Prisma.Decimal(currentValues.pernocta),
+      nocturnidad: new Prisma.Decimal(currentValues.nocturnidad),
+      festivo: new Prisma.Decimal(currentValues.festivo),
+      horas_extras: new Prisma.Decimal(currentValues.horas_extras),
+      otros_gastos: new Prisma.Decimal(currentValues.otros_gastos),
+      total_extras: new Prisma.Decimal(nextTotalExtras),
+      comment_cost: stringifyCommentCostMap(commentMap),
+    },
+  });
+}
+
 function parseDocumentType(value: unknown) {
   const key = toStringOrNull(value)?.toLowerCase();
   if (!key) {
@@ -603,7 +686,12 @@ export const handler = async (event: any) => {
         });
       }
 
-      await prisma.trainer_documents.delete({ where: { id: documentId } });
+      await prisma.$transaction(async (tx) => {
+        if (trainer.user_id && trainer.contrato_fijo) {
+          await removePayrollExpenseForDocument(tx, trainer.user_id, documentId);
+        }
+        await tx.trainer_documents.delete({ where: { id: documentId } });
+      });
 
       return successResponse({
         deleted: true,


### PR DESCRIPTION
### Motivation
- Ensure payroll extra amounts and comment mappings are kept consistent when a trainer document that recorded an expense is deleted.
- Perform the payroll update and document removal atomically to avoid orphaned expense references and inconsistent totals.

### Description
- Add `removePayrollExpenseForDocument` which locates the `office_payrolls` row referencing the given document id, removes the entry from the serialized `comment_cost` map, subtracts the expense from the resolved payroll column, clamps negative results to zero, recomputes `total_extras`, and updates the row with new `Prisma.Decimal` values.
- Update the document deletion flow to run inside `prisma.$transaction` and call `removePayrollExpenseForDocument(tx, trainer.user_id, documentId)` when the trainer has a `user_id` and `contrato_fijo`, then delete the `trainer_documents` row.
- Preserve existing Drive deletion behavior and add the payroll update to the same transaction so the update and deletion occur atomically.

### Testing
- Ran the backend test suite with `npm test` covering trainer document and payroll logic and all tests passed.
- Ran TypeScript compilation with `tsc --noEmit` and linting, both completing successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e679f4af648325ae7f2a879c8c4e2f)