### PR TITLE
fix: precio correcto en Pipedrive cuando se usa cupón del 100%

### DIFF
--- a/backend/functions/_shared/woocommerce-compras-pipedrive.ts
+++ b/backend/functions/_shared/woocommerce-compras-pipedrive.ts
@@ -53,6 +53,7 @@ type NormalizedWooOrder = {
   observations: string | null;
   couponCodes: string[];
   students: Student[];
+  isFullCouponOrder: boolean;
 };
 
 type PipedriveSyncResult = {
@@ -451,8 +452,12 @@ function normalizeWooOrder(payloadRoot: JsonObject): NormalizedWooOrder {
       : 0;
   const lineSubtotal = readNumber(lineItem.subtotal) ?? readNumber(payload.total) ?? 0;
   const unitPriceFromPayload = readNumber(lineItem.price);
-  const unitPrice =
-    unitPriceFromPayload ?? (resolvedQuantity > 0 && lineSubtotal > 0 ? lineSubtotal / resolvedQuantity : lineSubtotal);
+  // Cuando el cupón cubre el 100% del pedido, WooCommerce pone price=0 pero subtotal conserva
+  // el precio real de catálogo. En ese caso usamos subtotal como precio base en Pipedrive.
+  const isFullCouponOrder = (unitPriceFromPayload === null || unitPriceFromPayload === 0) && lineSubtotal > 0;
+  const unitPrice = isFullCouponOrder
+    ? (resolvedQuantity > 0 ? lineSubtotal / resolvedQuantity : lineSubtotal)
+    : (unitPriceFromPayload !== null ? unitPriceFromPayload : (resolvedQuantity > 0 && lineSubtotal > 0 ? lineSubtotal / resolvedQuantity : lineSubtotal));
 
   return {
     orderId,
@@ -493,6 +498,7 @@ function normalizeWooOrder(payloadRoot: JsonObject): NormalizedWooOrder {
     observations: pickMetaValue(orderMeta, ['custom_observations', 'meta_data_custom_observations', 'observations']),
     couponCodes: normalizeCouponCodes(payload),
     students: extractStudents(orderMeta),
+    isFullCouponOrder,
   };
 }
 
@@ -897,11 +903,13 @@ function buildAddProductPayload(order: NormalizedWooOrder, productIdPipe: string
     throw new Error(`El product_id de Pipedrive no es un entero válido: ${productIdPipe}`);
   }
 
+  const effectiveDiscount = order.isFullCouponOrder ? undefined : (discountPercentage > 0 ? discountPercentage : undefined);
+
   return {
     product_id: normalizedProductId,
     item_price: order.unitPrice,
     quantity: order.quantity,
-    discount: discountPercentage > 0 ? discountPercentage : undefined,
+    discount: effectiveDiscount,
     discount_type: 'percentage',
     tax_method: 'exclusive',
     tax: order.taxPercentage ?? undefined,


### PR DESCRIPTION
## Resumen

- Cuando WooCommerce aplica un cupón del 100%, el `price` del `line_item` llega a `0` pero `subtotal` conserva el precio real de catálogo.
- El código anterior enviaba `item_price: 0` a Pipedrive, dejando el producto sin valor en el deal.
- Además se arrastraba el descuento calculado (partner/cliente) aunque el precio ya fuera 0.

## Cambios

- **Detección de cupón 100%:** Se considera `isFullCouponOrder = true` cuando `price === 0` y `subtotal > 0` en el `line_item`.
- **Precio en Pipedrive:** Si `isFullCouponOrder`, se usa `lineItem.subtotal / quantity` como `item_price` (el precio real de catálogo).
- **Descuento en Pipedrive:** Si `isFullCouponOrder`, el descuento enviado es `undefined` (sin descuento), ya que el precio ya refleja el valor del presupuesto.

## Comportamiento resultante

| Escenario | `item_price` en Pipedrive | `discount` en Pipedrive |
|---|---|---|
| Venta directa (sin cupón) | `line_items[].price` | % calculado (partner/cliente) |
| Presupuesto comercial (cupón 100%) | `line_items[].subtotal / qty` | sin descuento |

https://claude.ai/code/session_01J2DQPBuncVxoE344qQR62u

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2DQPBuncVxoE344qQR62u)_