### PR TITLE
fix: 1 sesión por presupuesto de formación abierta (causa raíz)

### DIFF
--- a/backend/functions/_shared/sessionGeneration.ts
+++ b/backend/functions/_shared/sessionGeneration.ts
@@ -220,9 +220,13 @@ export async function generateSessionsForDeal(tx: Prisma.TransactionClient, deal
     return { ...product, id_pipe: resolvedPipeId };
   });
 
-  const applicableIds = applicableWithPipe.map((product: DealProductRecord) => product.id);
+  const isFormacionAbierta = isFormacionAbiertaPipeline(deal.pipeline_label);
 
-  if (applicableIds.length === 0) {
+  // Para formación abierta: 1 presupuesto → 1 sesión (solo el primer producto aplicable)
+  const productsToSync = isFormacionAbierta ? applicableWithPipe.slice(0, 1) : applicableWithPipe;
+  const syncProductIds = productsToSync.map((product: DealProductRecord) => product.id);
+
+  if (syncProductIds.length === 0) {
     const result = await tx.sesiones.deleteMany({ where: { deal_id: dealId } });
     return { count: 0, created: 0, deleted: result.count } as const;
   }
@@ -230,18 +234,18 @@ export async function generateSessionsForDeal(tx: Prisma.TransactionClient, deal
   const pruneResult = await tx.sesiones.deleteMany({
     where: {
       deal_id: dealId,
-      NOT: { deal_product_id: { in: applicableIds } },
+      NOT: { deal_product_id: { in: syncProductIds } },
     },
   });
 
   const syncResults = await Promise.all(
-    applicableWithPipe.map((product: DealProductRecord) =>
+    productsToSync.map((product: DealProductRecord) =>
       syncSessionsForProduct(
         tx,
         deal.deal_id,
         product,
         deal.training_address ?? null,
-        isFormacionAbiertaPipeline(deal.pipeline_label),
+        isFormacionAbierta,
       ),
     ),
   );

--- a/backend/functions/_shared/sessionGeneration.ts
+++ b/backend/functions/_shared/sessionGeneration.ts
@@ -160,6 +160,7 @@ export async function generateSessionsForDeal(tx: Prisma.TransactionClient, deal
       deal_id: true,
       training_address: true,
       pipeline_label: true,
+      pipeline_id: true,
       deal_products: {
         select: { id: true, deal_id: true, quantity: true, name: true, code: true },
       },
@@ -220,7 +221,8 @@ export async function generateSessionsForDeal(tx: Prisma.TransactionClient, deal
     return { ...product, id_pipe: resolvedPipeId };
   });
 
-  const isFormacionAbierta = isFormacionAbiertaPipeline(deal.pipeline_label);
+  // pipeline_label is often null; pipeline_id stores the resolved label string (see mappers.ts)
+  const isFormacionAbierta = isFormacionAbiertaPipeline(deal.pipeline_label ?? deal.pipeline_id);
 
   // Para formación abierta: 1 presupuesto → 1 sesión (solo el primer producto aplicable)
   const productsToSync = isFormacionAbierta ? applicableWithPipe.slice(0, 1) : applicableWithPipe;


### PR DESCRIPTION
## Problema

Para el embudo de **formación abierta**, el sistema creaba más sesiones de las debidas. El bug tenía **dos capas**:

### Capa 1 — múltiples productos
Con N productos aplicables, se creaba 1 sesión por producto aunque `forceSingleSession=true` limitara cada producto a 1. El iterador recorría todos los productos.

### Capa 2 — causa raíz ⚠️
`generateSessionsForDeal` leía `pipeline_label` de la BD para detectar si el deal es formación abierta. **Ese campo siempre es `null`** porque `mapAndUpsertDealTree` almacena el label del pipeline en la columna `pipeline_id` (no en `pipeline_label`). Resultado: `isFormacionAbiertaPipeline(null) = false` → `forceSingleSession = false` → se usaba `product.quantity` como número de sesiones. Un presupuesto con 1 producto y `quantity=2` generaba 2 sesiones.

## Solución

**Cambio 1** — `generateSessionsForDeal` itera solo el primer producto para formación abierta:
```
productsToSync = isFormacionAbierta ? applicableWithPipe.slice(0, 1) : applicableWithPipe
```

**Cambio 2** — Se añade `pipeline_id` al select y se usa como fallback:
```
isFormacionAbiertaPipeline(deal.pipeline_label ?? deal.pipeline_id)
```

## Comportamiento

| Escenario | Antes | Después |
|---|---|---|
| Formación Abierta, N productos | N sesiones | **1 sesión** |
| Formación Abierta, 1 producto quantity=2 | 2 sesiones | **1 sesión** |
| Resto de embudos | sin cambio | sin cambio |

https://claude.ai/code/session_017mo1SpQGJfFHgmt4hGmeRY

---
_Generated by [Claude Code](https://claude.ai/code/session_017mo1SpQGJfFHgmt4hGmeRY)_