### PR TITLE
Añadir campo Descuento a nóminas de oficina y costes extra de formadores

### DIFF
--- a/backend/functions/reporting-costes-extra.ts
+++ b/backend/functions/reporting-costes-extra.ts
@@ -20,6 +20,7 @@ const COST_FIELD_DEFINITIONS = [
   { key: 'festivo', column: 'festivo' },
   { key: 'horasExtras', column: 'horas_extras' },
   { key: 'gastosExtras', column: 'gastos_extras' },
+  { key: 'descuento', column: 'descuento' },
 ] as const;
 
 type CostFieldDefinition = (typeof COST_FIELD_DEFINITIONS)[number];
@@ -77,6 +78,7 @@ type ExtraCostRecord = {
   festivo: DecimalLike | number | string;
   horas_extras: DecimalLike | number | string;
   gastos_extras: DecimalLike | number | string;
+  descuento: DecimalLike | number | string;
   notas: string | null;
   created_at: Date;
   updated_at: Date;

--- a/backend/functions/reporting-nominas-oficina.ts
+++ b/backend/functions/reporting-nominas-oficina.ts
@@ -22,6 +22,7 @@ type OfficePayrollRow = office_payrolls & {
   horas_extras?: DecimalLike;
   otros_gastos?: DecimalLike;
   variable?: DecimalLike;
+  descuento?: DecimalLike;
   convenio?: string | null;
   antiguedad?: Date | null;
   horas_semana?: DecimalLike;
@@ -54,6 +55,7 @@ type OfficePayrollResponseItem = {
   horasExtras: number | null;
   otrosGastos: number | null;
   variable: number | null;
+  descuento: number | null;
   totalExtras: number | null;
   commentCost: string | null;
   commentPayroll: string | null;
@@ -110,6 +112,7 @@ type OfficePayrollPayload = {
   horasExtras?: unknown;
   otrosGastos?: unknown;
   variable?: unknown;
+  descuento?: unknown;
   totalExtras?: unknown;
   commentCost?: unknown;
   commentPayroll?: unknown;
@@ -262,6 +265,7 @@ function calculateExtrasTotal(record: {
   festivo?: DecimalLike;
   horas_extras?: DecimalLike;
   otros_gastos?: DecimalLike;
+  descuento?: DecimalLike;
 }): number | null {
   const persistedTotal = decimalToNumber(record.total_extras);
   if (persistedTotal !== null) return persistedTotal;
@@ -278,9 +282,11 @@ function calculateExtrasTotal(record: {
     .map((value) => decimalToNumber(value))
     .filter((value): value is number => value !== null);
 
-  if (values.length === 0) return null;
+  const descuento = decimalToNumber(record.descuento);
+  if (values.length === 0 && descuento === null) return null;
 
-  return Number(values.reduce((total, value) => total + value, 0));
+  const sum = values.length > 0 ? Number(values.reduce((total, value) => total + value, 0)) : 0;
+  return sum - (descuento ?? 0);
 }
 
 function calculateBrutoExtras(record: {
@@ -290,6 +296,7 @@ function calculateBrutoExtras(record: {
   festivo?: DecimalLike;
   horas_extras?: DecimalLike;
   variable?: DecimalLike;
+  descuento?: DecimalLike;
 }): number | null {
   const values = [
     record.otros_gastos,
@@ -302,9 +309,11 @@ function calculateBrutoExtras(record: {
     .map((value) => decimalToNumber(value))
     .filter((value): value is number => value !== null);
 
-  if (values.length === 0) return null;
+  const descuento = decimalToNumber(record.descuento);
+  if (values.length === 0 && descuento === null) return null;
 
-  return Number(values.reduce((total, value) => total + value, 0));
+  const sum = values.length > 0 ? Number(values.reduce((total, value) => total + value, 0)) : 0;
+  return sum - (descuento ?? 0);
 }
 
 function serializeRecord(
@@ -357,6 +366,7 @@ function serializeRecord(
     horasExtras: decimalToNumber(record.horas_extras),
     otrosGastos: decimalToNumber(record.otros_gastos),
     variable: decimalToNumber(record.variable),
+    descuento: decimalToNumber(record.descuento),
     totalExtras,
     commentCost: sanitizeText((record as { comment_cost?: unknown }).comment_cost),
     commentPayroll: sanitizeText(record.comment_payroll),
@@ -609,6 +619,7 @@ async function handlePut(prisma = getPrisma(), request: any) {
   const hasHorasExtras = hasField('horasExtras');
   const hasOtrosGastos = hasField('otrosGastos');
   const hasVariable = hasField('variable');
+  const hasDescuento = hasField('descuento');
   const hasTotalExtras = hasField('totalExtras');
   const hasCommentCost = hasField('commentCost');
   const hasCommentPayroll = hasField('commentPayroll');
@@ -636,6 +647,7 @@ async function handlePut(prisma = getPrisma(), request: any) {
   const horasExtras = hasHorasExtras ? parseDecimal(payload.horasExtras) : undefined;
   const otrosGastos = hasOtrosGastos ? parseDecimal(payload.otrosGastos) : undefined;
   const variable = hasVariable ? parseDecimal(payload.variable) : undefined;
+  const descuento = hasDescuento ? parseDecimal(payload.descuento) : undefined;
   const totalExtrasInput = hasTotalExtras ? parseDecimal(payload.totalExtras) : undefined;
   const commentCost = hasCommentCost ? sanitizeText(payload.commentCost) : undefined;
   const commentPayroll = hasCommentPayroll ? sanitizeText(payload.commentPayroll) : undefined;
@@ -709,7 +721,8 @@ async function handlePut(prisma = getPrisma(), request: any) {
     hasNocturnidad ||
     hasFestivo ||
     hasHorasExtras ||
-    hasOtrosGastos;
+    hasOtrosGastos ||
+    hasDescuento;
 
   const hasAnyBrutoExtraField =
     hasPernocta || hasNocturnidad || hasFestivo || hasHorasExtras || hasOtrosGastos || hasVariable;
@@ -722,6 +735,7 @@ async function handlePut(prisma = getPrisma(), request: any) {
   const currentHorasExtras = decimalToNumber(existingRecord?.horas_extras);
   const currentOtrosGastos = decimalToNumber(existingRecord?.otros_gastos);
   const currentVariable = decimalToNumber(existingRecord?.variable);
+  const currentDescuento = decimalToNumber(existingRecord?.descuento);
 
   const resolvedDietas = hasDietas ? dietas ?? null : currentDietas;
   const resolvedKilometrajes = hasKilometrajes ? kilometrajes ?? null : currentKilometrajes;
@@ -731,7 +745,7 @@ async function handlePut(prisma = getPrisma(), request: any) {
   const resolvedHorasExtras = hasHorasExtras ? horasExtras ?? null : currentHorasExtras;
   const resolvedOtrosGastos = hasOtrosGastos ? otrosGastos ?? null : currentOtrosGastos;
   const resolvedVariable = hasVariable ? variable ?? null : currentVariable;
-
+  const resolvedDescuento = hasDescuento ? descuento ?? null : currentDescuento;
 
   const currentSalarioBruto = decimalToNumber(existingRecord?.salario_bruto);
   const resolvedSalarioBruto = hasSalarioBruto ? salarioBruto ?? null : currentSalarioBruto;
@@ -742,6 +756,7 @@ async function handlePut(prisma = getPrisma(), request: any) {
     horas_extras: resolvedHorasExtras,
     otros_gastos: resolvedOtrosGastos,
     variable: resolvedVariable,
+    descuento: resolvedDescuento,
   });
   const resolvedSalarioBrutoTotal =
     resolvedSalarioBruto === null && resolvedSalarioBrutoExtras === null
@@ -757,6 +772,7 @@ async function handlePut(prisma = getPrisma(), request: any) {
         festivo: resolvedFestivo,
         horas_extras: resolvedHorasExtras,
         otros_gastos: resolvedOtrosGastos,
+        descuento: resolvedDescuento,
       })
     : hasTotalExtras
       ? totalExtrasInput ?? null
@@ -777,6 +793,7 @@ async function handlePut(prisma = getPrisma(), request: any) {
   if (hasOtrosGastos)
     updateData.otros_gastos = otrosGastos === null ? null : toDecimalOrNull(otrosGastos);
   if (hasVariable) updateData.variable = variable === null ? null : toDecimalOrNull(variable);
+  if (hasDescuento) updateData.descuento = descuento === null ? new Prisma.Decimal(0) : toDecimalOrNull(descuento) ?? new Prisma.Decimal(0);
   if (hasAnyExtrasField || hasTotalExtras) {
     updateData.total_extras =
       resolvedTotalExtras === null ? null : toDecimalOrNull(resolvedTotalExtras);
@@ -824,6 +841,7 @@ async function handlePut(prisma = getPrisma(), request: any) {
     festivo: hasFestivo ? festivo ?? null : null,
     horas_extras: hasHorasExtras ? horasExtras ?? null : null,
     otros_gastos: hasOtrosGastos ? otrosGastos ?? null : null,
+    descuento: hasDescuento ? descuento ?? null : null,
   });
 
   const record = await prisma.office_payrolls.upsert({
@@ -859,6 +877,7 @@ async function handlePut(prisma = getPrisma(), request: any) {
           : toDecimalOrNull(otrosGastos)
         : null,
       variable: hasVariable ? (variable === null ? null : toDecimalOrNull(variable)) : null,
+      descuento: hasDescuento ? (descuento === null ? new Prisma.Decimal(0) : toDecimalOrNull(descuento) ?? new Prisma.Decimal(0)) : new Prisma.Decimal(0),
       total_extras: createTotalExtras === null ? null : toDecimalOrNull(createTotalExtras),
       ...(hasCommentCost ? ({ comment_cost: commentCost ?? null } as Record<string, string | null>) : {}),
       ...(hasCommentPayroll

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -115,6 +115,7 @@ model office_payrolls {
   horas_extras                  Decimal?  @db.Decimal(12, 2)
   otros_gastos                  Decimal?  @db.Decimal(12, 2)
   variable                      Decimal?  @db.Decimal(12, 2)
+  descuento                     Decimal   @default(0) @db.Decimal(12, 2)
   total_extras                  Decimal?  @db.Decimal(12, 2)
   comment_cost                  String?
   comment_payroll               String?
@@ -857,6 +858,7 @@ model trainer_extra_costs {
   festivo                 Decimal  @default(0) @db.Decimal(12, 2)
   horas_extras            Decimal  @default(0) @db.Decimal(12, 2)
   gastos_extras           Decimal  @default(0) @db.Decimal(12, 2)
+  descuento               Decimal  @default(0) @db.Decimal(12, 2)
   notas                   String?
   created_at              DateTime @default(now()) @db.Timestamptz(6)
   updated_at              DateTime @default(now()) @updatedAt @db.Timestamptz(6)

--- a/frontend/src/features/reporting/api.ts
+++ b/frontend/src/features/reporting/api.ts
@@ -786,7 +786,8 @@ const EXTRA_COST_FIELD_KEYS = [
   'nocturnidad',
   'festivo',
   'horasExtras',
-  'gastosExtras'
+  'gastosExtras',
+  'descuento'
 ] as const;
 
 export type TrainerExtraCostFieldKey = (typeof EXTRA_COST_FIELD_KEYS)[number];
@@ -1275,6 +1276,7 @@ export type OfficePayrollRecord = {
   horasExtras: number | null;
   otrosGastos: number | null;
   variable: number | null;
+  descuento: number | null;
   totalExtras: number | null;
   commentCost: string | null;
   commentPayroll: string | null;
@@ -1351,6 +1353,7 @@ export type OfficePayrollUpsertPayload = {
   horasExtras?: number | string | null;
   otrosGastos?: number | string | null;
   variable?: number | string | null;
+  descuento?: number | string | null;
   totalExtras?: number | string | null;
   commentCost?: string | null;
   commentPayroll?: string | null;

--- a/frontend/src/pages/reporting/CostesExtraPage.tsx
+++ b/frontend/src/pages/reporting/CostesExtraPage.tsx
@@ -34,6 +34,7 @@ const COST_FIELD_DEFINITIONS: ReadonlyArray<{
   { key: 'festivo', label: 'Festivo' },
   { key: 'horasExtras', label: 'Horas extras' },
   { key: 'gastosExtras', label: 'Otros gastos' },
+  { key: 'descuento', label: 'Descuento' },
 ];
 
 const NON_HIGHLIGHT_COST_KEYS = new Set<TrainerExtraCostFieldKey>([
@@ -689,9 +690,18 @@ export default function CostesExtraPage({ onOpenBudgetSession }: CostesExtraPage
       }
 
       const draft = drafts[item.key] ?? createDraftFromItem(item);
+      const descuentoValue = parseInputToNumber(draft.fields['descuento']) ?? 0;
+      const hasFormacion = (item.costs.precioCosteFormacion ?? 0) > 0;
+      const hasPreventivo = (item.costs.precioCostePreventivo ?? 0) > 0;
+
       for (const definition of COST_FIELD_DEFINITIONS) {
         const parsed = parseInputToNumber(draft.fields[definition.key]);
-        const value = parsed ?? 0;
+        let value = parsed ?? 0;
+        if (definition.key === 'precioCosteFormacion' && hasFormacion) {
+          value -= descuentoValue;
+        } else if (definition.key === 'precioCostePreventivo' && hasPreventivo) {
+          value -= descuentoValue;
+        }
         totals[definition.key] += value;
         counts[definition.key] += 1;
       }

--- a/frontend/src/pages/reporting/NominasOficinaPage.tsx
+++ b/frontend/src/pages/reporting/NominasOficinaPage.tsx
@@ -209,7 +209,7 @@ type ExtrasModalProps = {
 };
 
 type ExtrasFieldConfig = {
-  key: 'dietas' | 'kilometraje' | 'pernocta' | 'nocturnidad' | 'festivo' | 'horasExtras' | 'otrosGastos' | 'variable';
+  key: 'dietas' | 'kilometraje' | 'pernocta' | 'nocturnidad' | 'festivo' | 'horasExtras' | 'otrosGastos' | 'variable' | 'descuento';
   label: string;
   col: number;
   entryKey: keyof OfficePayrollRecord;
@@ -227,6 +227,7 @@ const EXTRAS_SUMMARY_FIELDS = [
   { key: 'horasExtras', label: 'Horas extras', col: 6, entryKey: 'horasExtras', costsKey: 'horasExtras' },
   { key: 'otrosGastos', label: 'Otros gastos', col: 12, entryKey: 'otrosGastos', costsKey: 'gastosExtras' },
   { key: 'variable', label: 'Variable', col: 12, entryKey: 'variable' },
+  { key: 'descuento', label: 'Descuento', col: 12, entryKey: 'descuento' },
 ] as const satisfies ExtrasFieldConfig[];
 const EXTRAS_TOTAL_FIELDS: ExtrasSummaryKey[] = [
   'dietas',
@@ -487,7 +488,8 @@ function ExtrasModal({ entry, onHide, onSaved, allowEdit }: ExtrasModalProps) {
       const parsed = parseLocaleNumber(fields[key]) ?? 0;
       return sum + parsed;
     }, 0);
-    return total.toFixed(2);
+    const descuento = parseLocaleNumber(fields.descuento) ?? 0;
+    return (total - descuento).toFixed(2);
   }, [fields]);
 
   const mutation = useMutation({
@@ -783,6 +785,7 @@ const payrollInitialFields = {
   horasExtras: '',
   otrosGastos: '',
   variable: '',
+  descuento: '',
   commentPayroll: '',
 };
 
@@ -826,6 +829,7 @@ function buildPayrollFieldsFromEntry(entry: OfficePayrollRecord): typeof payroll
     horasExtras: resolveValue(entry.horasExtras),
     otrosGastos: resolveValue(entry.otrosGastos),
     variable: resolveValue(entry.variable),
+    descuento: resolveValue(entry.descuento),
     commentPayroll: resolveValue(entry.commentPayroll),
   });
 }
@@ -852,10 +856,11 @@ function applyPayrollCalculations(fields: typeof payrollInitialFields): typeof p
   const horasExtras = normalizeNumber(fields.horasExtras);
   const otrosGastos = normalizeNumber(fields.otrosGastos);
   const variable = normalizeNumber(fields.variable);
+  const descuento = normalizeNumber(fields.descuento);
   const brutoExtrasTotal =
-    pernocta === null && nocturnidad === null && festivo === null && horasExtras === null && otrosGastos === null && variable === null
+    pernocta === null && nocturnidad === null && festivo === null && horasExtras === null && otrosGastos === null && variable === null && descuento === null
       ? null
-      : (pernocta ?? 0) + (nocturnidad ?? 0) + (festivo ?? 0) + (horasExtras ?? 0) + (otrosGastos ?? 0) + (variable ?? 0);
+      : (pernocta ?? 0) + (nocturnidad ?? 0) + (festivo ?? 0) + (horasExtras ?? 0) + (otrosGastos ?? 0) + (variable ?? 0) - (descuento ?? 0);
   const salarioBrutoTotal =
     salarioBruto === null && brutoExtrasTotal === null ? null : (salarioBruto ?? 0) + (brutoExtrasTotal ?? 0);
   const retencionPorcentaje = parsePercentageInput(fields.retencion ?? '');

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -365,6 +365,7 @@ model trainer_extra_costs {
   festivo                 Decimal  @default(0) @db.Decimal(12, 2)
   horas_extras            Decimal  @default(0) @db.Decimal(12, 2)
   gastos_extras           Decimal  @default(0) @db.Decimal(12, 2)
+  descuento               Decimal  @default(0) @db.Decimal(12, 2)
   notas                   String?
   created_at              DateTime @default(now()) @db.Timestamptz(6)
   updated_at              DateTime @updatedAt @db.Timestamptz(6)


### PR DESCRIPTION
## Resumen

- **`office_payrolls`**: nuevo campo `descuento` (NUMERIC 12,2 DEFAULT 0) editable cada mes de forma independiente. Resta del `salario_bruto_total` y del `total_extras`. Aparece en el modal de Extras de las rutas `/usuarios/nominas_fijos` y `/usuarios/nominas_formadores_fijos`.
- **`trainer_extra_costs`**: nuevo campo `descuento` (NUMERIC 12,2 DEFAULT 0) editable por sesión/variante. Reduce el `coste_formacion` o `coste_preventivo` del formador. Aparece como nueva columna en `/usuarios/sesiones_y_costes_extra`.

## Cambios técnicos

### Base de datos (aplicado manualmente en NEON)
```sql
ALTER TABLE office_payrolls ADD COLUMN descuento NUMERIC(12, 2) NOT NULL DEFAULT 0;
ALTER TABLE trainer_extra_costs ADD COLUMN descuento NUMERIC(12, 2) NOT NULL DEFAULT 0;
```

### Backend
- `backend/prisma/schema.prisma`: campo `descuento` añadido a `office_payrolls` y `trainer_extra_costs`
- `prisma/schema.prisma`: campo `descuento` añadido a `trainer_extra_costs`
- `reporting-nominas-oficina.ts`: tipos, `calculateBrutoExtras`, `calculateExtrasTotal` y lógica PUT actualizados para restar el descuento
- `reporting-costes-extra.ts`: `descuento` añadido a `COST_FIELD_DEFINITIONS` y `ExtraCostRecord`

### Frontend
- `api.ts`: `descuento` añadido a `OfficePayrollRecord`, `OfficePayrollUpsertPayload` y `EXTRA_COST_FIELD_KEYS`
- `NominasOficinaPage.tsx`: campo Descuento en el modal de Extras, restado de `total_extras` y de `salario_bruto_total`
- `CostesExtraPage.tsx`: columna Descuento visible y editable; `tableSummary` resta el descuento de `precioCosteFormacion`/`precioCostePreventivo` según el tipo de sesión

## Fórmulas afectadas

```
salario_bruto_total = salario_bruto + (pernocta + nocturnidad + festivo + horas_extras + otros_gastos + variable) - descuento
total_extras = dietas + kilometrajes + pernocta + nocturnidad + festivo + horas_extras + otros_gastos + variable - descuento
```

https://claude.ai/code/session_019Ad3B4vKiFc1QYxsa3HnXQ

---
_Generated by [Claude Code](https://claude.ai/code/session_019Ad3B4vKiFc1QYxsa3HnXQ)_