### PR TITLE
Sincronizar alumnos WooCommerce directamente al recibir el pedido

### DIFF
--- a/backend/functions/woocommerce-compras-webhook.ts
+++ b/backend/functions/woocommerce-compras-webhook.ts
@@ -4,6 +4,7 @@ import type { Handler } from '@netlify/functions';
 import { COMMON_HEADERS } from './_shared/response';
 import { getPrisma } from './_shared/prisma';
 import { sendWooOrderToPipedrive } from './_shared/woocommerce-compras-pipedrive';
+import { importDealFromPipedrive } from './deals';
 
 const WOOCOMMERCE_COMPRAS_WEBHOOK_TOKEN = 'wc_compras_2026_ERP_GEP_4wJ8nK7pQ2xL9vR6tM1sH5dF3bY0cZ';
 const ACCEPTED_STATUSES = new Set(['completed', 'completado']);
@@ -266,6 +267,30 @@ export const handler: Handler = async (event) => {
       });
     } catch (error) {
       console.error('[woocommerce-compras-webhook] Failed to auto-send order to Pipedrive', error);
+    }
+
+    // Importamos el deal al ERP directamente tras el envío a Pipedrive, sin esperar al
+    // webhook de vuelta. En este punto las notas con alumnos ya existen en Pipedrive
+    // (creadas por sendWooOrderToPipedrive antes de marcar el deal como ganado), por lo
+    // que importDealFromPipedrive las encontrará y sincronizará sesiones y alumnos.
+    if (autoSendResult?.dealId) {
+      try {
+        await importDealFromPipedrive(autoSendResult.dealId);
+        console.log(
+          JSON.stringify({
+            event: 'woocommerce-deal-erpimport-success',
+            deal_id: autoSendResult.dealId,
+            order_number: summary.orderNumber,
+          }),
+        );
+      } catch (importError) {
+        console.error('[woocommerce-compras-webhook] Error al importar deal al ERP tras envío a Pipedrive', {
+          dealId: autoSendResult.dealId,
+          error: importError instanceof Error
+            ? { message: importError.message, stack: importError.stack }
+            : importError,
+        });
+      }
     }
 
     return jsonResponse(200, {


### PR DESCRIPTION
## Por qué no funcionaba el fix anterior

El PR anterior corregía el handler del **webhook de nota** de Pipedrive, pero el problema raíz para los presupuestos WooCommerce ("WC-") es diferente:

### El flujo real de WooCommerce

```
1. WooCommerce order → webhook ERP → sendWooOrderToPipedrive()
   ├── Crea deal en Pipedrive (status: open)
   ├── Añade producto
   ├── Crea NOTA con alumnos ← los datos están aquí
   └── Actualiza deal a "won"
         ↓ (de forma asíncrona Pipedrive envía webhooks de vuelta)
2. Pipedrive webhook nota → ERP: deal aún NO está en BD → SKIP
3. Pipedrive webhook deal-won → ERP: importDealFromPipedrive()
   └── getDealNotes() puede devolver vacío (eventual consistency de la API)
       → 0 alumnos sincronizados
4. Usuario abre presupuesto → frontend sincroniza alumnos
```

### Por qué fallaba

Dos condiciones de carrera simultáneas:
1. El webhook de nota llega **antes** de que el deal esté en la BD del ERP → ignorado
2. Cuando llega el webhook de deal-won, la API de Pipedrive puede devolver las notas vacías momentáneamente (la nota se creó milisegundos antes del PUT que disparó el webhook)

## La solución

Llamar `importDealFromPipedrive` **directamente** al final del handler de WooCommerce, justo después de que `sendWooOrderToPipedrive` confirme que el deal está ganado en Pipedrive. En ese momento:
- ✅ Las notas con alumnos **ya están confirmadas** en Pipedrive (creadas en el paso 3 de `sendWooOrderToPipedrive`)
- ✅ El deal es "won" en Pipedrive (actualizado en el paso 4)
- ✅ No hay race condition: todo está en orden antes de llamar al import

`importDealFromPipedrive` internamente llama a `syncFormacionAbiertaSessionsAndStudents`, que crea sesiones y alumnos en la BD del ERP.

El webhook de deal-won de Pipedrive seguirá llegando después y disparará `importDealFromPipedrive` de nuevo — idempotente, no duplica alumnos.

## Cambio

Solo 1 fichero: `backend/functions/woocommerce-compras-webhook.ts`

```typescript
// Después de sendWooOrderToPipedrive():
if (autoSendResult?.dealId) {
  await importDealFromPipedrive(autoSendResult.dealId);
}
```

https://claude.ai/code/session_01NKf1DPBxW7NdrAwovpnJFv

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKf1DPBxW7NdrAwovpnJFv)_