### PR TITLE
fix: corregir corte de texto en cabecera columna Kilometraje

### DIFF
--- a/frontend/src/pages/reporting/CostesExtraPage.tsx
+++ b/frontend/src/pages/reporting/CostesExtraPage.tsx
@@ -906,7 +906,7 @@ export default function CostesExtraPage({ onOpenBudgetSession }: CostesExtraPage
                   key={definition.key}
                   className="text-end bg-light"
                   style={{
-                    width: definition.key === 'nocturnidad' ? '94px' : '78px',
+                    width: definition.key === 'nocturnidad' || definition.key === 'kilometraje' ? '94px' : '78px',
                     position: 'sticky',
                     top: 0,
                     zIndex: 3,


### PR DESCRIPTION
## Descripción

La columna "Kilometraje" en la tabla de Sesiones y Costes Extra mostraba el texto cortado como "Kilometraj-e" porque su ancho era de 78px, insuficiente para la palabra completa.

## Cambio realizado

Se amplía el ancho de la columna `kilometraje` de 78px a 94px, igualándola a la columna `nocturnidad` que también tiene 11 caracteres y ya disponía de ese ancho.

El cambio es de una línea en `CostesExtraPage.tsx`:
```
width: definition.key === 'nocturnidad' || definition.key === 'kilometraje' ? '94px' : '78px'
```

No se modifica ningún label (el texto "Kilometraje" se mantiene íntegro en cabecera, Excel y desplegable).

https://claude.ai/code/session_01P4ndBRDHSniFNRGi4CeyQG

---
_Generated by [Claude Code](https://claude.ai/code/session_01P4ndBRDHSniFNRGi4CeyQG)_