### PR TITLE
Corregir parser de alumnos y auto-sync en webhook WooCommerce

### DIFF
--- a/backend/functions/_shared/studentsFromNotes.ts
+++ b/backend/functions/_shared/studentsFromNotes.ts
@@ -85,58 +85,42 @@ function parseEntry(entry: string) {
     .map((part) => normalizeWhitespace(part.replace(/^["']+/, '').replace(/["']+$/, '')))
     .filter((part) => part.length > 0);
 
-  if (rawParts.length < 2) {
+  // Formato esperado: Nombre | Apellido [| Email] | DNI
+  // El último campo siempre es el DNI (posicional, igual que el parser del frontend).
+  // Usar detección dinámica de teléfono causaba que DNIs españoles (8 dígitos + letra)
+  // se clasificaran como teléfonos, dejando solo 1 parte y devolviendo null.
+  if (rawParts.length < 3) {
     return null;
   }
 
-  const parts = [...rawParts];
+  const nombre = rawParts[0];
+  const lastPart = rawParts[rawParts.length - 1];
+  const dni = normalizeDni(lastPart);
 
+  if (!nombre.length || !dni) {
+    return null;
+  }
+
+  const middleParts = rawParts.slice(1, -1);
+
+  // Si algún campo intermedio contiene '@', es el email; el resto es el apellido.
   let email: string | null = null;
-  let telefono: string | null = null;
-  let dni: string | null = null;
-
-  for (let index = parts.length - 1; index >= 0; index -= 1) {
-    const part = parts[index];
-    if (!email) {
-      const normalizedEmail = normalizeEmail(part);
-      if (normalizedEmail) {
-        email = normalizedEmail;
-        parts.splice(index, 1);
-        continue;
-      }
-    }
-
-    if (!telefono) {
-      const normalizedPhone = normalizePhone(part);
-      if (normalizedPhone) {
-        telefono = normalizedPhone;
-        parts.splice(index, 1);
-        continue;
-      }
-    }
-
-    if (!dni) {
-      const normalizedDni = normalizeDni(part);
-      if (normalizedDni) {
-        dni = normalizedDni;
-        parts.splice(index, 1);
-        continue;
-      }
+  const apellidoParts: string[] = [];
+  for (const part of middleParts) {
+    const normalizedEmail = normalizeEmail(part);
+    if (normalizedEmail && !email) {
+      email = normalizedEmail;
+    } else {
+      apellidoParts.push(part);
     }
   }
 
-  if (parts.length < 2) {
+  const apellido = normalizeWhitespace(apellidoParts.join(' '));
+  if (!apellido.length) {
     return null;
   }
 
-  const nombre = parts[0];
-  const apellido = normalizeWhitespace(parts.slice(1).join(' '));
-
-  if (!nombre.length || !apellido.length) {
-    return null;
-  }
-
-  return { nombre, apellido, dni, email, telefono };
+  return { nombre, apellido, dni, email, telefono: null };
 }
 
 export function studentsFromNotes(notes: readonly NoteRecord[] | null | undefined): ParsedNoteStudent[] {

--- a/backend/functions/woocommerce-compras-webhook.ts
+++ b/backend/functions/woocommerce-compras-webhook.ts
@@ -4,6 +4,7 @@ import type { Handler } from '@netlify/functions';
 import { COMMON_HEADERS } from './_shared/response';
 import { getPrisma } from './_shared/prisma';
 import { sendWooOrderToPipedrive } from './_shared/woocommerce-compras-pipedrive';
+import { importDealFromPipedrive } from './deals';
 
 const WOOCOMMERCE_COMPRAS_WEBHOOK_TOKEN = 'wc_compras_2026_ERP_GEP_4wJ8nK7pQ2xL9vR6tM1sH5dF3bY0cZ';
 const ACCEPTED_STATUSES = new Set(['completed', 'completado']);
@@ -266,6 +267,30 @@ export const handler: Handler = async (event) => {
       });
     } catch (error) {
       console.error('[woocommerce-compras-webhook] Failed to auto-send order to Pipedrive', error);
+    }
+
+    // Importamos el deal al ERP directamente tras el envío a Pipedrive, sin esperar al
+    // webhook de vuelta. En este punto las notas con alumnos ya existen en Pipedrive
+    // (creadas por sendWooOrderToPipedrive antes de marcar el deal como ganado), por lo
+    // que importDealFromPipedrive las encontrará y sincronizará sesiones y alumnos.
+    if (autoSendResult?.dealId) {
+      try {
+        await importDealFromPipedrive(autoSendResult.dealId);
+        console.log(
+          JSON.stringify({
+            event: 'woocommerce-deal-erpimport-success',
+            deal_id: autoSendResult.dealId,
+            order_number: summary.orderNumber,
+          }),
+        );
+      } catch (importError) {
+        console.error('[woocommerce-compras-webhook] Error al importar deal al ERP tras envío a Pipedrive', {
+          dealId: autoSendResult.dealId,
+          error: importError instanceof Error
+            ? { message: importError.message, stack: importError.stack }
+            : importError,
+        });
+      }
     }
 
     return jsonResponse(200, {


### PR DESCRIPTION
## El problema raíz real: bug en el parser `studentsFromNotes`

El backend tiene un parser que intenta detectar el **tipo** de cada campo de forma dinámica (email, teléfono, DNI) escaneando desde el final de la entrada. Este parser tiene un bug crítico:

### ¿Por qué fallaba con DNIs españoles?

Para una entrada como `Enrique | Molina Griggs | 12345678A`:

1. **Campo `12345678A`**: tiene 8 dígitos → el detector de teléfonos lo clasifica como teléfono (umbral: ≥7 dígitos) ❌
2. **Campo `Molina Griggs`**: `MOLINAGRIGGS` = 12 caracteres alfanuméricos ≥ 5 → detectado como DNI ❌
3. **Resultado**: solo queda `['Enrique']` → `parts.length < 2` → `return null` → **ningún alumno**

El frontend tenía un parser más simple y correcto: **el último campo siempre es el DNI** (posicional). Por eso funcionaba al abrir el presupuesto pero no en el backend.

### La corrección

Se unifica el comportamiento con el frontend:

```
rawParts[0]      → nombre
rawParts[-1]     → DNI (posicional, siempre)
rawParts[1..-2]  → apellido (campos intermedios)
si algún campo intermedio tiene '@' → email
```

Ahora `Enrique | Molina Griggs | 12345678A` se parsea correctamente:
- nombre: `Enrique`
- apellido: `Molina Griggs`  
- dni: `12345678A` ✅

---

## Problema secundario: condición de carrera con webhooks WooCommerce

El flujo de `sendWooOrderToPipedrive`:
1. Crea deal en Pipedrive (open)
2. Añade producto
3. **Crea nota con alumnos** ← aquí están los datos
4. Actualiza deal a "won" → Pipedrive envía webhook de vuelta

Pipedrive enviaba el webhook de nota ANTES de que el deal estuviera en la BD del ERP → ignorado. Luego llegaba el webhook de deal-won, pero `getDealNotes` podía devolver vacío (consistencia eventual de la API de Pipedrive).

**Solución**: llamar `importDealFromPipedrive` directamente al finalizar `sendWooOrderToPipedrive`, cuando las notas YA están confirmadas en Pipedrive y el deal es "won". Sin esperar webhooks.

---

## Archivos modificados

- `backend/functions/_shared/studentsFromNotes.ts` — parser corregido
- `backend/functions/woocommerce-compras-webhook.ts` — llamada directa a `importDealFromPipedrive`

https://claude.ai/code/session_01NKf1DPBxW7NdrAwovpnJFv

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKf1DPBxW7NdrAwovpnJFv)_