### PR TITLE
Edición de logs de informes en actuaciones preventivos

### DIFF
--- a/backend/functions/actuaciones-preventivos.ts
+++ b/backend/functions/actuaciones-preventivos.ts
@@ -79,6 +79,125 @@ export const handler = createHttpHandler<any>(async (request) => {
     return successResponse({ informes: records });
   }
 
+  if (request.method === 'PUT') {
+    const prisma = getPrisma();
+    const auth = await requireAuth(request, prisma);
+    if ('error' in auth) {
+      return auth.error;
+    }
+
+    const body = request.body && typeof request.body === 'object' ? request.body : {};
+
+    const id = trimToNull(body.id);
+    if (!id) {
+      return errorResponse('VALIDATION_ERROR', 'El campo id es obligatorio.', 400);
+    }
+
+    const dealId = trimToNull(body.dealId ?? body.presupuesto);
+    if (!dealId) {
+      return errorResponse('VALIDATION_ERROR', 'El campo presupuesto/dealId es obligatorio.', 400);
+    }
+
+    const fechaEjercicio = parseRequiredDate(body.fechaEjercicio);
+    if (!fechaEjercicio) {
+      return errorResponse('VALIDATION_ERROR', 'El campo fechaEjercicio es obligatorio.', 400);
+    }
+
+    const partesTrabajo = parseOptionalInteger(body.partesTrabajo);
+    if (body.partesTrabajo !== null && body.partesTrabajo !== undefined && body.partesTrabajo !== '' && partesTrabajo === null) {
+      return errorResponse('VALIDATION_ERROR', 'El campo partesTrabajo debe ser numérico y mayor o igual que 0.', 400);
+    }
+
+    const asistenciasSanitarias = parseOptionalInteger(body.asistenciasSanitarias);
+    if (
+      body.asistenciasSanitarias !== null &&
+      body.asistenciasSanitarias !== undefined &&
+      body.asistenciasSanitarias !== '' &&
+      asistenciasSanitarias === null
+    ) {
+      return errorResponse('VALIDATION_ERROR', 'El campo asistenciasSanitarias debe ser numérico y mayor o igual que 0.', 400);
+    }
+
+    const derivaronMutua = parseOptionalInteger(body.derivaronMutua);
+    if (
+      body.derivaronMutua !== null &&
+      body.derivaronMutua !== undefined &&
+      body.derivaronMutua !== '' &&
+      derivaronMutua === null
+    ) {
+      return errorResponse('VALIDATION_ERROR', 'El campo derivaronMutua debe ser numérico y mayor o igual que 0.', 400);
+    }
+
+    const derivacionAmbulancia = parseOptionalInteger(body.derivacionAmbulancia);
+    if (
+      body.derivacionAmbulancia !== null &&
+      body.derivacionAmbulancia !== undefined &&
+      body.derivacionAmbulancia !== '' &&
+      derivacionAmbulancia === null
+    ) {
+      return errorResponse('VALIDATION_ERROR', 'El campo derivacionAmbulancia debe ser numérico y mayor o igual que 0.', 400);
+    }
+
+    const hasAsistenciasSanitarias = (asistenciasSanitarias ?? 0) > 0;
+    const derivaronMutuaFinal = hasAsistenciasSanitarias ? derivaronMutua : null;
+    const derivacionAmbulanciaFinal = hasAsistenciasSanitarias ? derivacionAmbulancia : null;
+
+    const turno = trimToNull(body.turno) ?? 'Mañana';
+    if (!ALLOWED_TURNO_VALUES.includes(turno as (typeof ALLOWED_TURNO_VALUES)[number])) {
+      return errorResponse('VALIDATION_ERROR', 'El campo turno debe ser Mañana o Noche.', 400);
+    }
+
+    const existing: any[] = await prisma.$queryRawUnsafe(
+      `SELECT id FROM actuaciones_preventivos_informes WHERE id = $1`,
+      id,
+    );
+    if (!existing.length) {
+      return errorResponse('NOT_FOUND', 'No se encontró el informe indicado.', 404);
+    }
+
+    const updated: any = await prisma.$queryRawUnsafe(
+      `
+        UPDATE actuaciones_preventivos_informes SET
+          deal_id = $2,
+          cliente = $3,
+          persona_contacto = $4,
+          direccion_preventivo = $5,
+          bombero = $6,
+          fecha_ejercicio = $7,
+          turno = $8,
+          partes_trabajo = $9,
+          asistencias_sanitarias = $10,
+          derivaron_mutua = $11,
+          derivacion_ambulancia = $12,
+          observaciones = $13,
+          responsable = $14,
+          updated_at = NOW()
+        WHERE id = $1
+        RETURNING
+          id, deal_id, cliente, persona_contacto, direccion_preventivo, bombero,
+          fecha_ejercicio, turno, partes_trabajo, asistencias_sanitarias,
+          derivaron_mutua, derivacion_ambulancia, observaciones, responsable,
+          created_by_user_id, created_at, updated_at
+      `,
+      id,
+      dealId,
+      trimToNull(body.cliente),
+      trimToNull(body.personaContacto),
+      trimToNull(body.direccionPreventivo),
+      trimToNull(body.bombero),
+      fechaEjercicio,
+      turno,
+      partesTrabajo,
+      asistenciasSanitarias,
+      derivaronMutuaFinal,
+      derivacionAmbulanciaFinal,
+      trimToNull(body.observaciones),
+      trimToNull(body.responsable),
+    );
+
+    return successResponse({ informe: Array.isArray(updated) ? updated[0] : updated });
+  }
+
   if (request.method !== 'POST') {
     return METHOD_NOT_ALLOWED;
   }

--- a/frontend/src/features/reporting/api.ts
+++ b/frontend/src/features/reporting/api.ts
@@ -1523,6 +1523,59 @@ export type ActuacionesPreventivosFilters = {
   endDate?: string;
 };
 
+export type ActuacionesPreventivosUpdatePayload = {
+  id: string;
+  dealId: string;
+  fechaEjercicio: string;
+  cliente?: string | null;
+  personaContacto?: string | null;
+  direccionPreventivo?: string | null;
+  bombero?: string | null;
+  turno?: string | null;
+  partesTrabajo?: number | null;
+  asistenciasSanitarias?: number | null;
+  derivaronMutua?: number | null;
+  derivacionAmbulancia?: number | null;
+  observaciones?: string | null;
+  responsable?: string | null;
+};
+
+export async function updateActuacionesPreventivosInforme(
+  payload: ActuacionesPreventivosUpdatePayload
+): Promise<ActuacionesPreventivosInforme> {
+  const response = await putJson<{ informe?: unknown }>('/actuaciones-preventivos', payload);
+  const raw = response?.informe;
+  if (!raw || typeof raw !== 'object') {
+    throw new Error('Respuesta inválida del servidor.');
+  }
+  const r = raw as Record<string, unknown>;
+  const id = sanitizeText(r.id);
+  const dealId = sanitizeText(r.deal_id);
+  const fechaEjercicio = sanitizeDate(r.fecha_ejercicio);
+  if (!id || !dealId || !fechaEjercicio) {
+    throw new Error('Respuesta inválida del servidor.');
+  }
+  return {
+    id,
+    dealId,
+    cliente: sanitizeText(r.cliente),
+    personaContacto: sanitizeText(r.persona_contacto),
+    direccionPreventivo: sanitizeText(r.direccion_preventivo),
+    bombero: sanitizeText(r.bombero),
+    fechaEjercicio,
+    turno: sanitizeText(r.turno),
+    partesTrabajo: sanitizeInteger(r.partes_trabajo) ?? 0,
+    asistenciasSanitarias: sanitizeInteger(r.asistencias_sanitarias) ?? 0,
+    derivaronMutua: sanitizeInteger(r.derivaron_mutua) ?? 0,
+    derivacionAmbulancia: sanitizeInteger(r.derivacion_ambulancia) ?? 0,
+    observaciones: sanitizeText(r.observaciones),
+    responsable: sanitizeText(r.responsable),
+    createdByUserId: sanitizeText(r.created_by_user_id),
+    createdAt: sanitizeDate(r.created_at),
+    updatedAt: sanitizeDate(r.updated_at),
+  };
+}
+
 export async function fetchActuacionesPreventivosInformes(
   filters: ActuacionesPreventivosFilters = {}
 ): Promise<ActuacionesPreventivosInforme[]> {

--- a/frontend/src/pages/reporting/ActuacionesPreventivosDashboardPage.tsx
+++ b/frontend/src/pages/reporting/ActuacionesPreventivosDashboardPage.tsx
@@ -1,6 +1,6 @@
-import { useMemo, useState } from 'react';
-import { keepPreviousData, useQuery } from '@tanstack/react-query';
-import { Alert, Badge, Button, Card, Col, Form, Row, Spinner, Table } from 'react-bootstrap';
+import { useMemo, useRef, useState } from 'react';
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Alert, Badge, Button, Card, Col, Form, Modal, Row, Spinner, Table } from 'react-bootstrap';
 import type { Content, TableCell } from 'pdfmake/interfaces';
 import pdfMake from 'pdfmake/build/pdfmake';
 import pdfFonts from 'pdfmake/build/vfs_fonts';
@@ -8,6 +8,7 @@ import preventivoHeaderImg from '../../features/informes/assets/pdf/header.png';
 import { isApiError } from '../../api/client';
 import {
   fetchActuacionesPreventivosInformes,
+  updateActuacionesPreventivosInforme,
   type ActuacionesPreventivosInforme,
 } from '../../features/reporting/api';
 import { emitToast } from '../../utils/toast';
@@ -262,6 +263,41 @@ function buildKpiRows(informes: ActuacionesPreventivosInforme[], granularity: Gr
     });
 }
 
+type EditFormState = {
+  dealId: string;
+  fechaEjercicio: string;
+  cliente: string;
+  personaContacto: string;
+  direccionPreventivo: string;
+  bombero: string;
+  turno: string;
+  partesTrabajo: string;
+  asistenciasSanitarias: string;
+  derivaronMutua: string;
+  derivacionAmbulancia: string;
+  observaciones: string;
+  responsable: string;
+};
+
+function informeToFormState(informe: ActuacionesPreventivosInforme): EditFormState {
+  const fecha = parseDateSafe(informe.fechaEjercicio);
+  return {
+    dealId: informe.dealId,
+    fechaEjercicio: fecha ? formatDateInput(fecha) : '',
+    cliente: informe.cliente ?? '',
+    personaContacto: informe.personaContacto ?? '',
+    direccionPreventivo: informe.direccionPreventivo ?? '',
+    bombero: informe.bombero ?? '',
+    turno: informe.turno ?? 'Mañana',
+    partesTrabajo: String(informe.partesTrabajo),
+    asistenciasSanitarias: String(informe.asistenciasSanitarias),
+    derivaronMutua: String(informe.derivaronMutua),
+    derivacionAmbulancia: String(informe.derivacionAmbulancia),
+    observaciones: informe.observaciones ?? '',
+    responsable: informe.responsable ?? '',
+  };
+}
+
 export default function ActuacionesPreventivosDashboardPage() {
   const today = useMemo(() => new Date(), []);
   const [granularity, setGranularity] = useState<Granularity>('mes');
@@ -271,6 +307,10 @@ export default function ActuacionesPreventivosDashboardPage() {
   const [selectedWeekKey, setSelectedWeekKey] = useState<string>(ACCUMULATED_WEEK_KEY);
   const [heatMapMonth, setHeatMapMonth] = useState<number>(0);
   const [heatMapShift, setHeatMapShift] = useState<ShiftFilter>('todos');
+  const [editingInforme, setEditingInforme] = useState<ActuacionesPreventivosInforme | null>(null);
+  const [editForm, setEditForm] = useState<EditFormState | null>(null);
+  const editFormRef = useRef<HTMLFormElement>(null);
+  const queryClient = useQueryClient();
 
   const informesQuery = useQuery({
     queryKey: ['reporting', 'actuaciones-preventivos', startDate, endDate],
@@ -282,6 +322,57 @@ export default function ActuacionesPreventivosDashboardPage() {
     placeholderData: keepPreviousData,
     staleTime: 60_000,
   });
+
+  const updateMutation = useMutation({
+    mutationFn: updateActuacionesPreventivosInforme,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['reporting', 'actuaciones-preventivos'] });
+      setEditingInforme(null);
+      setEditForm(null);
+      emitToast({ variant: 'success', message: 'Informe actualizado correctamente.' });
+    },
+    onError: (error) => {
+      emitToast({
+        variant: 'danger',
+        message: isApiError(error) ? error.message : 'No se pudo actualizar el informe.',
+      });
+    },
+  });
+
+  const handleOpenEdit = (informe: ActuacionesPreventivosInforme) => {
+    setEditingInforme(informe);
+    setEditForm(informeToFormState(informe));
+  };
+
+  const handleCloseEdit = () => {
+    setEditingInforme(null);
+    setEditForm(null);
+  };
+
+  const handleEditFieldChange = (field: keyof EditFormState, value: string) => {
+    setEditForm((prev) => (prev ? { ...prev, [field]: value } : prev));
+  };
+
+  const handleEditSubmit = (event: { preventDefault: () => void }) => {
+    event.preventDefault();
+    if (!editingInforme || !editForm) return;
+    updateMutation.mutate({
+      id: editingInforme.id,
+      dealId: editForm.dealId,
+      fechaEjercicio: editForm.fechaEjercicio,
+      cliente: editForm.cliente || null,
+      personaContacto: editForm.personaContacto || null,
+      direccionPreventivo: editForm.direccionPreventivo || null,
+      bombero: editForm.bombero || null,
+      turno: editForm.turno || null,
+      partesTrabajo: editForm.partesTrabajo !== '' ? Number(editForm.partesTrabajo) : null,
+      asistenciasSanitarias: editForm.asistenciasSanitarias !== '' ? Number(editForm.asistenciasSanitarias) : null,
+      derivaronMutua: editForm.derivaronMutua !== '' ? Number(editForm.derivaronMutua) : null,
+      derivacionAmbulancia: editForm.derivacionAmbulancia !== '' ? Number(editForm.derivacionAmbulancia) : null,
+      observaciones: editForm.observaciones || null,
+      responsable: editForm.responsable || null,
+    });
+  };
 
   const informes = informesQuery.data ?? [];
 
@@ -688,6 +779,7 @@ export default function ActuacionesPreventivosDashboardPage() {
   };
 
   return (
+    <>
     <section className="py-3 d-grid gap-3">
       <Card className="shadow-sm">
         <Card.Header as="h1" className="h4 mb-0">Dashboard - Actuaciones preventivos</Card.Header>
@@ -1047,6 +1139,7 @@ export default function ActuacionesPreventivosDashboardPage() {
               <Table striped bordered hover size="sm" className="align-middle mb-0">
                 <thead>
                   <tr>
+                    <th>Acciones</th>
                     <th>Fecha ejercicio</th>
                     <th>Deal ID</th>
                     <th>Cliente</th>
@@ -1065,6 +1158,15 @@ export default function ActuacionesPreventivosDashboardPage() {
                 <tbody>
                   {informes.map((informe) => (
                     <tr key={informe.id}>
+                      <td className="text-nowrap">
+                        <Button
+                          variant="outline-primary"
+                          size="sm"
+                          onClick={() => handleOpenEdit(informe)}
+                        >
+                          Editar
+                        </Button>
+                      </td>
                       <td>{formatDateDisplay(informe.fechaEjercicio)}</td>
                       <td className="text-nowrap">{informe.dealId}</td>
                       <td>{informe.cliente ?? '—'}</td>
@@ -1087,5 +1189,173 @@ export default function ActuacionesPreventivosDashboardPage() {
         </Card.Body>
       </Card>
     </section>
+
+    <Modal show={editingInforme !== null} onHide={handleCloseEdit} size="lg">
+      <Modal.Header closeButton>
+        <Modal.Title>Editar informe</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        {editForm && (
+          <Form ref={editFormRef} onSubmit={handleEditSubmit} id="edit-informe-form">
+            <Row className="g-3">
+              <Col xs={12} md={6}>
+                <Form.Group controlId="edit-dealId">
+                  <Form.Label>Deal ID / Presupuesto <span className="text-danger">*</span></Form.Label>
+                  <Form.Control
+                    required
+                    value={editForm.dealId}
+                    onChange={(e) => handleEditFieldChange('dealId', e.target.value)}
+                  />
+                </Form.Group>
+              </Col>
+              <Col xs={12} md={6}>
+                <Form.Group controlId="edit-fechaEjercicio">
+                  <Form.Label>Fecha ejercicio <span className="text-danger">*</span></Form.Label>
+                  <Form.Control
+                    required
+                    type="date"
+                    value={editForm.fechaEjercicio}
+                    onChange={(e) => handleEditFieldChange('fechaEjercicio', e.target.value)}
+                  />
+                </Form.Group>
+              </Col>
+              <Col xs={12} md={6}>
+                <Form.Group controlId="edit-cliente">
+                  <Form.Label>Cliente</Form.Label>
+                  <Form.Control
+                    value={editForm.cliente}
+                    onChange={(e) => handleEditFieldChange('cliente', e.target.value)}
+                  />
+                </Form.Group>
+              </Col>
+              <Col xs={12} md={6}>
+                <Form.Group controlId="edit-personaContacto">
+                  <Form.Label>Persona de contacto</Form.Label>
+                  <Form.Control
+                    value={editForm.personaContacto}
+                    onChange={(e) => handleEditFieldChange('personaContacto', e.target.value)}
+                  />
+                </Form.Group>
+              </Col>
+              <Col xs={12} md={6}>
+                <Form.Group controlId="edit-direccionPreventivo">
+                  <Form.Label>Dirección preventivo</Form.Label>
+                  <Form.Control
+                    value={editForm.direccionPreventivo}
+                    onChange={(e) => handleEditFieldChange('direccionPreventivo', e.target.value)}
+                  />
+                </Form.Group>
+              </Col>
+              <Col xs={12} md={6}>
+                <Form.Group controlId="edit-bombero">
+                  <Form.Label>Bombero</Form.Label>
+                  <Form.Control
+                    value={editForm.bombero}
+                    onChange={(e) => handleEditFieldChange('bombero', e.target.value)}
+                  />
+                </Form.Group>
+              </Col>
+              <Col xs={12} md={6}>
+                <Form.Group controlId="edit-turno">
+                  <Form.Label>Turno</Form.Label>
+                  <Form.Select
+                    value={editForm.turno}
+                    onChange={(e) => handleEditFieldChange('turno', e.target.value)}
+                  >
+                    <option value="Mañana">Mañana</option>
+                    <option value="Noche">Noche</option>
+                  </Form.Select>
+                </Form.Group>
+              </Col>
+              <Col xs={12} md={6}>
+                <Form.Group controlId="edit-responsable">
+                  <Form.Label>Responsable</Form.Label>
+                  <Form.Control
+                    value={editForm.responsable}
+                    onChange={(e) => handleEditFieldChange('responsable', e.target.value)}
+                  />
+                </Form.Group>
+              </Col>
+              <Col xs={6} md={3}>
+                <Form.Group controlId="edit-partesTrabajo">
+                  <Form.Label>Partes trabajo</Form.Label>
+                  <Form.Control
+                    type="number"
+                    min={0}
+                    value={editForm.partesTrabajo}
+                    onChange={(e) => handleEditFieldChange('partesTrabajo', e.target.value)}
+                  />
+                </Form.Group>
+              </Col>
+              <Col xs={6} md={3}>
+                <Form.Group controlId="edit-asistenciasSanitarias">
+                  <Form.Label>Asistencias sanitarias</Form.Label>
+                  <Form.Control
+                    type="number"
+                    min={0}
+                    value={editForm.asistenciasSanitarias}
+                    onChange={(e) => handleEditFieldChange('asistenciasSanitarias', e.target.value)}
+                  />
+                </Form.Group>
+              </Col>
+              <Col xs={6} md={3}>
+                <Form.Group controlId="edit-derivaronMutua">
+                  <Form.Label>Derivaron a Mútua</Form.Label>
+                  <Form.Control
+                    type="number"
+                    min={0}
+                    value={editForm.derivaronMutua}
+                    onChange={(e) => handleEditFieldChange('derivaronMutua', e.target.value)}
+                  />
+                </Form.Group>
+              </Col>
+              <Col xs={6} md={3}>
+                <Form.Group controlId="edit-derivacionAmbulancia">
+                  <Form.Label>Derivación ambulancia</Form.Label>
+                  <Form.Control
+                    type="number"
+                    min={0}
+                    value={editForm.derivacionAmbulancia}
+                    onChange={(e) => handleEditFieldChange('derivacionAmbulancia', e.target.value)}
+                  />
+                </Form.Group>
+              </Col>
+              <Col xs={12}>
+                <Form.Group controlId="edit-observaciones">
+                  <Form.Label>Observaciones</Form.Label>
+                  <Form.Control
+                    as="textarea"
+                    rows={3}
+                    value={editForm.observaciones}
+                    onChange={(e) => handleEditFieldChange('observaciones', e.target.value)}
+                  />
+                </Form.Group>
+              </Col>
+            </Row>
+          </Form>
+        )}
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="secondary" onClick={handleCloseEdit} disabled={updateMutation.isPending}>
+          Cancelar
+        </Button>
+        <Button
+          variant="primary"
+          type="submit"
+          form="edit-informe-form"
+          disabled={updateMutation.isPending}
+        >
+          {updateMutation.isPending ? (
+            <>
+              <Spinner animation="border" size="sm" className="me-2" />
+              Guardando...
+            </>
+          ) : (
+            'Guardar cambios'
+          )}
+        </Button>
+      </Modal.Footer>
+    </Modal>
+    </>
   );
 }


### PR DESCRIPTION
## Resumen

- Añade botón **"Editar"** en cada fila de la tabla "Logs de informes" del dashboard `/reporting/actuaciones_preventivos`
- Al pulsar el botón se abre un **modal** con todos los campos del informe editables: Deal ID, fecha de ejercicio, cliente, contacto, dirección, bombero, turno, partes de trabajo, asistencias sanitarias, derivaciones a mútua/ambulancia, observaciones y responsable
- Nuevo endpoint **PUT `/actuaciones-preventivos`** en el backend que valida y persiste los cambios en base de datos
- Tras guardar, la tabla se refresca automáticamente y se muestra un toast de confirmación

## Plan de pruebas

- [ ] Abrir `/reporting/actuaciones_preventivos` con datos en el rango seleccionado
- [ ] Verificar que aparece la columna "Acciones" con el botón "Editar" en cada fila
- [ ] Pulsar "Editar" y comprobar que el modal se abre con los valores actuales del informe
- [ ] Modificar uno o varios campos y guardar
- [ ] Verificar que la tabla se actualiza con los nuevos valores
- [ ] Verificar que se muestra toast de éxito
- [ ] Verificar que campos obligatorios (Deal ID, fecha) muestran validación HTML5 si se dejan vacíos

https://claude.ai/code/session_01JFbrBgEr5KUDaHZWBiBvN4

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFbrBgEr5KUDaHZWBiBvN4)_