### PR TITLE
fix(pipedrive): corrige mapeo del campo Formación desde WooCommerce

### DIFF
--- a/backend/functions/_shared/woocommerce-compras-pipedrive.ts
+++ b/backend/functions/_shared/woocommerce-compras-pipedrive.ts
@@ -716,14 +716,13 @@ async function resolveDealSingleOptionValues(
   order: NormalizedWooOrder,
   resolvedProduct: ProductResolution,
 ): Promise<DealSingleOptionValues> {
-  const trainingPrimaryLabel = readString(order.productName);
-  const trainingLookupCandidates = trainingPrimaryLabel
-    ? [trainingPrimaryLabel]
-    : buildTrainingLookupCandidates([order.productName, resolvedProduct.productName]);
-  const trainingFallbackCandidates = trainingPrimaryLabel
-    ? buildTrainingLookupCandidates([resolvedProduct.productName, order.productName]).filter((candidate) => candidate !== trainingPrimaryLabel)
-    : [];
-  const trainingLookupLabel = trainingPrimaryLabel ?? trainingLookupCandidates[0] ?? null;
+  // Always generate all candidate variations (with/without "Curso " prefix, with/without type suffix)
+  // using both the WooCommerce product name and the resolved DB product name as sources
+  const trainingLookupCandidates = buildTrainingLookupCandidates([
+    order.productName,
+    resolvedProduct.productName,
+  ]);
+  const trainingLookupLabel = readString(order.productName) ?? trainingLookupCandidates[0] ?? null;
   const siteLookupLabel = order.formattedLocation ?? order.rawLocation;
   const normalizedFundae = normalizeBooleanText(order.fundae);
   const fundaeLookupLabel = normalizedFundae === 'yes' ? 'Sí' : normalizedFundae === 'no' ? 'No' : order.fundae;
@@ -734,7 +733,6 @@ async function resolveDealSingleOptionValues(
       fieldKey: DEAL_TRAINING_FIELD_KEY,
       fieldName: 'Formación',
       candidateLabels: trainingLookupCandidates,
-      fallbackLabels: trainingFallbackCandidates,
     }),
     resolveSingleOptionId(prisma, {
       fieldKey: DEAL_SITE_FIELD_KEY,
@@ -864,7 +862,10 @@ function buildDealCreatePayload(
     visible_to: DEFAULT_VISIBLE_TO,
     [DEAL_SERVICE_FIELD_KEY]: DEAL_INITIAL_SERVICE_VALUE,
     [DEAL_TRAINING_DATE_FIELD_KEY]: order.formattedDate,
-    [DEAL_TRAINING_FIELD_KEY]: singleOptionValues.trainingOptionId,
+    // Only send the training field if a match was found — sending null clears the value in Pipedrive
+    ...(singleOptionValues.trainingOptionId !== null && {
+      [DEAL_TRAINING_FIELD_KEY]: singleOptionValues.trainingOptionId,
+    }),
     [DEAL_WC_ORDER_FIELD_KEY]: order.orderId,
     [DEAL_TRAFFIC_SOURCE_FIELD_KEY]: order.trafficSource,
     [DEAL_SOURCE_FIELD_KEY]: DEAL_INITIAL_SOURCE_VALUE,
@@ -885,8 +886,14 @@ function buildDealUpdatePayload(
     visible_to: DEFAULT_VISIBLE_TO,
     currency: order.subtotal > 0 ? 'EUR' : undefined,
     [DEAL_SERVICE_FIELD_KEY]: lifecycle.serviceValue,
-    [DEAL_TRAINING_FIELD_KEY]: singleOptionValues.trainingOptionId,
-    [DEAL_SITE_FIELD_KEY]: singleOptionValues.siteOptionId,
+    // Only send the training field if a match was found — sending null clears the value in Pipedrive
+    ...(singleOptionValues.trainingOptionId !== null && {
+      [DEAL_TRAINING_FIELD_KEY]: singleOptionValues.trainingOptionId,
+    }),
+    // Only send the site field if a match was found
+    ...(singleOptionValues.siteOptionId !== null && {
+      [DEAL_SITE_FIELD_KEY]: singleOptionValues.siteOptionId,
+    }),
     [DEAL_STUDENTS_FIELD_KEY]: String(order.quantity),
     [DEAL_FUNDAE_FIELD_KEY]: singleOptionValues.fundaeOptionId,
     [DEAL_WC_ORDER_FIELD_KEY]: `Order en Woocommerce: ${order.orderNumber}`,


### PR DESCRIPTION
## Problema

El campo **Formación** del deal en Pipedrive quedaba siempre vacío (`-`) al procesar una venta de WooCommerce, aunque el producto comprado tuviera un mapeo válido.

## Causa raíz (3 bugs)

### Bug 1 — Generación asimétrica de candidatos de búsqueda
En `resolveDealSingleOptionValues`, cuando `productName` tenía valor, los candidatos primarios eran simplemente `[productName]` sin pasar por `buildTrainingLookupCandidates`. Esto significaba que las variaciones del nombre (sin prefijo `"Curso "`, sin sufijo `"- empresa"`, etc.) solo llegaban a los candidatos de **fallback**, y si Pipedrive tenía la opción etiquetada de una forma ligeramente diferente, la búsqueda fallaba.

**Antes:**
```typescript
const trainingLookupCandidates = trainingPrimaryLabel
  ? [trainingPrimaryLabel]  // ← solo el nombre crudo, sin variaciones
  : buildTrainingLookupCandidates([...]);
```

**Después:** siempre se generan todas las variaciones desde ambas fuentes (WooCommerce y BD local).

### Bug 2 — Se enviaba `null` a Pipedrive cuando la búsqueda fallaba
Cuando no se encontraba coincidencia, ambos payloads (create y update) enviaban `[DEAL_TRAINING_FIELD_KEY]: null`. La API de Pipedrive interpreta `null` como "borrar el campo", garantizando que quedara vacío incluso si ya tenía valor.

### Bug 3 — El mismo problema de `null` afectaba al campo Sede de la Formación
El campo `DEAL_SITE_FIELD_KEY` en `buildDealUpdatePayload` también enviaba `null` cuando no había coincidencia.

## Solución

- `resolveDealSingleOptionValues`: siempre usa `buildTrainingLookupCandidates([order.productName, resolvedProduct.productName])` como candidatos (elimina la lógica primario/fallback asimétrica)
- `buildDealCreatePayload` y `buildDealUpdatePayload`: solo incluyen `DEAL_TRAINING_FIELD_KEY` y `DEAL_SITE_FIELD_KEY` en el payload cuando se ha encontrado una coincidencia (usando spread condicional)

## Acción adicional recomendada

Verificar que la tabla `pipedrive_custom_field_options` esté sincronizada: hacer un POST a `/api/pipedrive-custom-fields` para refrescar las opciones desde Pipedrive. Si la tabla está vacía, ninguna búsqueda puede tener éxito independientemente de la lógica de candidatos.

https://claude.ai/code/session_01E129Qqztb5ugDiUoVQFM8s

---
_Generated by [Claude Code](https://claude.ai/code/session_01E129Qqztb5ugDiUoVQFM8s)_