### PR TITLE
feat: backfill one-shot centro_coste en deals existentes

### DIFF
--- a/backend/functions/backfill-centro-coste-background.ts
+++ b/backend/functions/backfill-centro-coste-background.ts
@@ -1,0 +1,89 @@
+// Función de backfill ONE-SHOT para rellenar centro_coste en deals existentes.
+// Uso: POST /api/backfill-centro-coste con header x-webhook-token: <PIPEDRIVE_WEBHOOK_TOKEN>
+// ELIMINAR este archivo una vez ejecutado correctamente.
+
+import type { BackgroundHandler } from "@netlify/functions";
+import { getDeal, getDealFields, findFieldDef, optionLabelOf } from "./_shared/pipedrive";
+import { getPrisma } from "./_shared/prisma";
+
+const KEY_CENTRO_COSTE = "21e21e35f209ba485a2e8a209e35eda396875d11";
+const EXPECTED_TOKEN = process.env.PIPEDRIVE_WEBHOOK_TOKEN;
+
+// 5 deals en paralelo, pausa de 625ms entre lotes → ~8 llamadas/s, bien bajo el límite de Pipedrive
+const CONCURRENCY = 5;
+const BATCH_DELAY_MS = 625;
+
+async function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+export const handler: BackgroundHandler = async (event) => {
+  // — Auth —
+  const token =
+    event.headers["x-webhook-token"] ??
+    event.headers["authorization"]?.replace(/^Bearer\s+/i, "");
+
+  if (!EXPECTED_TOKEN || token !== EXPECTED_TOKEN) {
+    console.error("[backfill-centro-coste] Token inválido, abortando.");
+    return;
+  }
+
+  console.log("[backfill-centro-coste] Iniciando...");
+  const prisma = getPrisma();
+
+  // Obtener todos los deal_id de la BD
+  const rows = await prisma.deals.findMany({ select: { deal_id: true } });
+  const total = rows.length;
+  console.log(`[backfill-centro-coste] Deals a procesar: ${total}`);
+
+  // Obtener definición de campos de Pipedrive (una sola vez)
+  const dealFields = await getDealFields();
+  const fCentroCoste = findFieldDef(dealFields, KEY_CENTRO_COSTE);
+
+  let updated = 0;
+  let nulled = 0;
+  let errors = 0;
+
+  // Procesar en lotes de CONCURRENCY
+  for (let i = 0; i < rows.length; i += CONCURRENCY) {
+    const batch = rows.slice(i, i + CONCURRENCY);
+
+    await Promise.all(
+      batch.map(async ({ deal_id }) => {
+        try {
+          const dealData = await getDeal(deal_id);
+
+          const centroCoste = fCentroCoste
+            ? (optionLabelOf(fCentroCoste, dealData?.[fCentroCoste.key]) ?? null)
+            : dealData?.[KEY_CENTRO_COSTE]
+              ? String(dealData[KEY_CENTRO_COSTE]).trim() || null
+              : null;
+
+          await prisma.deals.update({
+            where: { deal_id },
+            data: { centro_coste: centroCoste },
+          });
+
+          if (centroCoste) updated++;
+          else nulled++;
+        } catch (e) {
+          console.error(`[backfill-centro-coste] Error en deal ${deal_id}:`, e);
+          errors++;
+        }
+      }),
+    );
+
+    const done = Math.min(i + CONCURRENCY, total);
+    console.log(
+      `[backfill-centro-coste] ${done}/${total} — ✓ ${updated} con valor, — ${nulled} sin valor, ✗ ${errors} errores`,
+    );
+
+    if (i + CONCURRENCY < rows.length) {
+      await sleep(BATCH_DELAY_MS);
+    }
+  }
+
+  console.log(
+    `[backfill-centro-coste] COMPLETADO. ${updated} actualizados con valor, ${nulled} sin valor (null), ${errors} errores.`,
+  );
+};

--- a/netlify.toml
+++ b/netlify.toml
@@ -68,6 +68,12 @@
   to = "/.netlify/functions/deals/import"
   status = 200
 
+# Backfill one-shot (ELIMINAR tras ejecutar)
+[[redirects]]
+  from = "/api/backfill-centro-coste"
+  to = "/.netlify/functions/backfill-centro-coste-background"
+  status = 200
+
 # Auth (endpoints explícitos)
 [[redirects]]
   from = "/auth/login"


### PR DESCRIPTION
## ⚠️ PR temporal — eliminar tras ejecutar el backfill

### Qué hace
Background Function de Netlify que rellena el campo `centro_coste` en todos los deals existentes de la BD consultando la API de Pipedrive.

### Cómo ejecutarlo

1. Mergear este PR y esperar al deploy de Netlify
2. Hacer la llamada (desde Postman, curl o cualquier cliente HTTP):

```
POST https://<tu-dominio>/api/backfill-centro-coste
Header: x-webhook-token: <valor de PIPEDRIVE_WEBHOOK_TOKEN>
```

3. La respuesta será un **202 inmediato** — la función corre en segundo plano durante ~10-12 minutos
4. Revisar los logs en **Netlify → Functions → backfill-centro-coste-background** para ver el progreso y el resultado final

### Qué hace exactamente
- Lee todos los `deal_id` de la tabla `deals` (~4500)
- Para cada deal llama a la API de Pipedrive y obtiene el label de `centro_coste`
- Hace `UPDATE deals SET centro_coste = ? WHERE deal_id = ?`
- Procesa 5 deals en paralelo con 625ms de pausa entre lotes (~8 req/s, muy por debajo del límite de Pipedrive)

### Tras ejecutarlo correctamente
Abrir un PR que elimine:
- `backend/functions/backfill-centro-coste-background.ts`
- El redirect `/api/backfill-centro-coste` de `netlify.toml`

---
_Generated by [Claude Code](https://claude.ai/code/session_01PabkXzyH7M9smL7meQeiUF)_