### PR TITLE
fix: usar webhook_key para autenticar el backfill de centro_coste

### DIFF
--- a/backend/functions/backfill-centro-coste-background.ts
+++ b/backend/functions/backfill-centro-coste-background.ts
@@ -1,5 +1,5 @@
 // Función de backfill ONE-SHOT para rellenar centro_coste en deals existentes.
-// Uso: POST /api/backfill-centro-coste con header x-webhook-token: <PIPEDRIVE_WEBHOOK_TOKEN>
+// Uso: POST /api/backfill-centro-coste con header x-webhook-token: <webhook_key>
 // ELIMINAR este archivo una vez ejecutado correctamente.
 
 import type { BackgroundHandler } from "@netlify/functions";
@@ -7,7 +7,7 @@ import { getDeal, getDealFields, findFieldDef, optionLabelOf } from "./_shared/p
 import { getPrisma } from "./_shared/prisma";
 
 const KEY_CENTRO_COSTE = "21e21e35f209ba485a2e8a209e35eda396875d11";
-const EXPECTED_TOKEN = process.env.PIPEDRIVE_WEBHOOK_TOKEN;
+const EXPECTED_TOKEN = process.env.webhook_key;
 
 // 5 deals en paralelo, pausa de 625ms entre lotes → ~8 llamadas/s, bien bajo el límite de Pipedrive
 const CONCURRENCY = 5;


### PR DESCRIPTION
Corrección rápida: la función de backfill buscaba `PIPEDRIVE_WEBHOOK_TOKEN` pero la variable de entorno real en Netlify se llama `webhook_key`.

**Tras mergear y que Netlify haga deploy (~2 min), ejecutar:**

```javascript
fetch('https://erpgep.netlify.app/.netlify/functions/backfill-centro-coste-background', {
  method: 'POST',
  headers: { 'x-webhook-token': 'snVV5w^xl2LAKt.^@X~&KNuL/Su9%F#D/_SL;h0GT]~t[jeD-F' }
}).then(r => console.log(r.status === 202 ? '✅ Lanzado correctamente' : '❌ Error: ' + r.status))
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01PabkXzyH7M9smL7meQeiUF)_