### PR TITLE
Filtro por Centro de Coste y tabla de sesiones en comparativa

### DIFF
--- a/backend/functions/reporting-comparativa.ts
+++ b/backend/functions/reporting-comparativa.ts
@@ -194,6 +194,7 @@ type SessionRow = {
     caes_val: boolean | null;
     hotel_val: boolean | null;
     comercial: string | null;
+    centro_coste: string | null;
     organizations: {
       name: string;
     } | null;
@@ -434,6 +435,13 @@ export const handler = createHttpHandler(async (request) => {
         request.event.multiValueQueryStringParameters?.comerciales ??
         request.event.multiValueQueryStringParameters?.costCenterId,
     );
+  const costCenters =
+    parseStringArrayParam(request.query.costCenter ?? request.query.costCenters ?? request.query.centro_coste) ??
+    parseStringArrayParam(
+      request.event.multiValueQueryStringParameters?.costCenter ??
+        request.event.multiValueQueryStringParameters?.costCenters ??
+        request.event.multiValueQueryStringParameters?.centro_coste,
+    );
 
   const [
     currentSessionsRaw,
@@ -450,6 +458,7 @@ export const handler = createHttpHandler(async (request) => {
           ...(siteFilters ? { sede_label: { in: siteFilters } } : {}),
           ...(trainingTypes ? { pipeline_id: { in: trainingTypes } } : {}),
           ...(comerciales ? { comercial: { in: comerciales } } : {}),
+          ...(costCenters ? { centro_coste: { in: costCenters } } : {}),
         },
       },
       select: {
@@ -464,6 +473,7 @@ export const handler = createHttpHandler(async (request) => {
             caes_val: true,
             hotel_val: true,
             comercial: true,
+            centro_coste: true,
             organizations: {
               select: {
                 name: true,
@@ -498,6 +508,7 @@ export const handler = createHttpHandler(async (request) => {
           ...(siteFilters ? { sede_label: { in: siteFilters } } : {}),
           ...(trainingTypes ? { pipeline_id: { in: trainingTypes } } : {}),
           ...(comerciales ? { comercial: { in: comerciales } } : {}),
+          ...(costCenters ? { centro_coste: { in: costCenters } } : {}),
         },
       },
       select: {
@@ -512,6 +523,7 @@ export const handler = createHttpHandler(async (request) => {
             caes_val: true,
             hotel_val: true,
             comercial: true,
+            centro_coste: true,
             organizations: {
               select: {
                 name: true,
@@ -590,9 +602,11 @@ export const handler = createHttpHandler(async (request) => {
         ...(siteFilters ? { sede_label: { in: siteFilters } } : {}),
         ...(trainingTypes ? { pipeline_id: { in: trainingTypes } } : {}),
         ...(comerciales ? { comercial: { in: comerciales } } : {}),
+        ...(costCenters ? { centro_coste: { in: costCenters } } : {}),
       },
       select: {
         w_id_variation: true,
+        centro_coste: true,
         organizations: {
           select: {
             name: true,
@@ -607,9 +621,11 @@ export const handler = createHttpHandler(async (request) => {
         ...(siteFilters ? { sede_label: { in: siteFilters } } : {}),
         ...(trainingTypes ? { pipeline_id: { in: trainingTypes } } : {}),
         ...(comerciales ? { comercial: { in: comerciales } } : {}),
+        ...(costCenters ? { centro_coste: { in: costCenters } } : {}),
       },
       select: {
         w_id_variation: true,
+        centro_coste: true,
         organizations: {
           select: {
             name: true,
@@ -636,13 +652,20 @@ export const handler = createHttpHandler(async (request) => {
   );
 
   const currentVariantOrgById = new Map<string, string>();
+  const currentVariantCostCenterById = new Map<string, string>();
   for (const deal of currentVariantDeals as Array<{
     w_id_variation: unknown;
+    centro_coste?: string | null;
     organizations?: { name: string } | null;
   }>) {
     const normalizedId = normalizeVariantWooId(deal.w_id_variation);
-    if (!normalizedId || currentVariantOrgById.has(normalizedId)) continue;
-    currentVariantOrgById.set(normalizedId, normalizeLabel(deal.organizations?.name, 'Sin organización'));
+    if (!normalizedId) continue;
+    if (!currentVariantOrgById.has(normalizedId)) {
+      currentVariantOrgById.set(normalizedId, normalizeLabel(deal.organizations?.name, 'Sin organización'));
+    }
+    if (!currentVariantCostCenterById.has(normalizedId) && deal.centro_coste?.trim()) {
+      currentVariantCostCenterById.set(normalizedId, deal.centro_coste.trim());
+    }
   }
 
   const filteredCurrentVariants = currentVariants.filter((variant) => {
@@ -1131,6 +1154,39 @@ export const handler = createHttpHandler(async (request) => {
     ...mergeCounts(gepServicesTypeCurrentCounts, gepServicesTypePreviousCounts, 'gepServicesType'),
   ];
 
+  type CostCenterBreakdownEntry = { costCenter: string; gepServices: number; formacionEmpresa: number; formacionAbierta: number };
+  const costCenterMap = new Map<string, CostCenterBreakdownEntry>();
+
+  const getCostCenterEntry = (cc: string): CostCenterBreakdownEntry => {
+    if (!costCenterMap.has(cc)) {
+      costCenterMap.set(cc, { costCenter: cc, gepServices: 0, formacionEmpresa: 0, formacionAbierta: 0 });
+    }
+    return costCenterMap.get(cc)!;
+  };
+
+  for (const session of currentSessions) {
+    const classif = classifySession(session);
+    if (!classif) continue;
+    const cc = session.deals?.centro_coste?.trim() || 'Sin centro de coste';
+    const entry = getCostCenterEntry(cc);
+    if (classif === 'gepServices') entry.gepServices++;
+    else if (classif === 'formacionEmpresa') entry.formacionEmpresa++;
+    else if (classif === 'formacionAbierta') entry.formacionAbierta++;
+  }
+
+  for (const variant of filteredCurrentVariants) {
+    const normalizedId = normalizeVariantWooId(variant.id_woo);
+    const cc = (normalizedId ? currentVariantCostCenterById.get(normalizedId) : null) ?? 'Sin centro de coste';
+    getCostCenterEntry(cc).formacionAbierta++;
+  }
+
+  const costCenterBreakdown = Array.from(costCenterMap.values())
+    .sort((a, b) => {
+      const totalA = a.gepServices + a.formacionEmpresa + a.formacionAbierta;
+      const totalB = b.gepServices + b.formacionEmpresa + b.formacionAbierta;
+      return totalB - totalA || a.costCenter.localeCompare(b.costCenter);
+    });
+
   const mobileUnitsUsage = Array.from(mobileUnitSessionsMap.values())
     .map((item) => ({
       key: item.key,
@@ -1154,16 +1210,18 @@ export const handler = createHttpHandler(async (request) => {
     ...mobileUnitSessionGroups,
   ];
 
-  const [dealSites, variantSites, pipelineOptions, comercialOptions]: [
+  const [dealSites, variantSites, pipelineOptions, comercialOptions, costCenterOptions]: [
     { sede_label: string | null }[],
     { sede: string | null }[],
     { pipeline_id: string | null }[],
     { comercial: string | null }[],
+    { centro_coste: string | null }[],
   ] = await Promise.all([
     prisma.deals.findMany({ distinct: ['sede_label'], select: { sede_label: true } }),
     prisma.variants.findMany({ distinct: ['sede'], select: { sede: true } }),
     prisma.deals.findMany({ distinct: ['pipeline_id'], select: { pipeline_id: true } }),
     prisma.deals.findMany({ distinct: ['comercial'], select: { comercial: true } }),
+    prisma.deals.findMany({ distinct: ['centro_coste'], select: { centro_coste: true } }),
   ]);
 
   const siteOptionSet = new Set<string>();
@@ -1184,6 +1242,10 @@ export const handler = createHttpHandler(async (request) => {
       .sort((a, b) => a.localeCompare(b)),
     comerciales: comercialOptions
       .map((item) => item.comercial?.trim())
+      .filter((value): value is string => Boolean(value))
+      .sort((a, b) => a.localeCompare(b)),
+    costCenters: costCenterOptions
+      .map((item) => item.centro_coste?.trim())
       .filter((value): value is string => Boolean(value))
       .sort((a, b) => a.localeCompare(b)),
   } as const;
@@ -1225,6 +1287,7 @@ export const handler = createHttpHandler(async (request) => {
     metricSessions,
     listingSessions,
     mobileUnitsUsage,
+    costCenterBreakdown,
     filterOptions,
   });
 });

--- a/frontend/src/features/reporting/api.ts
+++ b/frontend/src/features/reporting/api.ts
@@ -1105,6 +1105,7 @@ export type ComparativaFilters = {
   siteIds?: string[];
   trainingTypes?: string[];
   comerciales?: string[];
+  costCenterIds?: string[];
   serviceType?: string;
 };
 
@@ -1215,6 +1216,13 @@ export type ComparativaMobileUnitUsage = {
   currentValue: number;
 };
 
+export type ComparativaCostCenterBreakdown = {
+  costCenter: string;
+  gepServices: number;
+  formacionEmpresa: number;
+  formacionAbierta: number;
+};
+
 export type ComparativaDashboardResponse = {
   highlights: ComparativaKpi[];
   trends: ComparativaTrend[];
@@ -1227,10 +1235,12 @@ export type ComparativaDashboardResponse = {
   metricSessions: ComparativaMetricSessionGroup[];
   listingSessions: ComparativaSessionGroup[];
   mobileUnitsUsage: ComparativaMobileUnitUsage[];
+  costCenterBreakdown: ComparativaCostCenterBreakdown[];
   filterOptions: {
     sites: string[];
     trainingTypes: string[];
     comerciales: string[];
+    costCenters: string[];
   };
 };
 
@@ -1248,6 +1258,7 @@ export async function fetchComparativaDashboard(
   filters.siteIds?.forEach((siteId) => params.append('siteId', siteId));
   filters.trainingTypes?.forEach((trainingType) => params.append('trainingType', trainingType));
   filters.comerciales?.forEach((comercial) => params.append('comercial', comercial));
+  filters.costCenterIds?.forEach((cc) => params.append('costCenter', cc));
   if (filters.serviceType) params.set('serviceType', filters.serviceType);
 
   const query = params.toString();

--- a/frontend/src/pages/reporting/ComparativaDashboardPage.tsx
+++ b/frontend/src/pages/reporting/ComparativaDashboardPage.tsx
@@ -10,6 +10,7 @@ import {
   type ComparativaBinaryMix,
   type ComparativaTrend,
   type ComparativaSessionGroup,
+  type ComparativaCostCenterBreakdown,
 } from '../../features/reporting/api';
 
 const METRIC_CONFIG: { key: string; label: string }[] = [
@@ -301,8 +302,12 @@ export default function ComparativaDashboardPage() {
       badges.push({ label: 'Tipo de formación', value: filters.trainingTypes.join(', ') });
     }
 
+    if (filters.costCenterIds?.length) {
+      badges.push({ label: 'Centro de coste', value: filters.costCenterIds.join(', ') });
+    }
+
     return badges;
-  }, [filters.comerciales, filters.siteIds, filters.trainingTypes]);
+  }, [filters.comerciales, filters.siteIds, filters.trainingTypes, filters.costCenterIds]);
 
   const dashboardQuery = useQuery({
     queryKey: [
@@ -316,6 +321,7 @@ export default function ComparativaDashboardPage() {
       appliedFilters.siteIds?.join(',') ?? '',
       appliedFilters.trainingTypes?.join(',') ?? '',
       appliedFilters.comerciales?.join(',') ?? '',
+      appliedFilters.costCenterIds?.join(',') ?? '',
     ],
     queryFn: () => fetchComparativaDashboard(appliedFilters),
     placeholderData: keepPreviousData,
@@ -376,6 +382,7 @@ export default function ComparativaDashboardPage() {
   const siteOptions = dashboardQuery.data?.filterOptions.sites ?? [];
   const trainingTypeOptions = dashboardQuery.data?.filterOptions.trainingTypes ?? [];
   const comercialOptions = dashboardQuery.data?.filterOptions.comerciales ?? [];
+  const costCenterOptions = dashboardQuery.data?.filterOptions.costCenters ?? [];
 
   const handleDateChange = (
     period: 'currentPeriod' | 'previousPeriod',
@@ -447,7 +454,7 @@ export default function ComparativaDashboardPage() {
   };
 
   const handleMultiSelectorChange = (
-    key: keyof Pick<ComparativaFilters, 'siteIds' | 'trainingTypes' | 'comerciales'>,
+    key: keyof Pick<ComparativaFilters, 'siteIds' | 'trainingTypes' | 'comerciales' | 'costCenterIds'>,
     values: string[],
   ) => {
     setFilters((prev) => ({
@@ -874,6 +881,68 @@ export default function ComparativaDashboardPage() {
     );
   };
 
+  const renderCostCenterBreakdown = () => {
+    const items: ComparativaCostCenterBreakdown[] = dashboardQuery.data?.costCenterBreakdown ?? [];
+
+    return (
+      <Card className="h-100 shadow-sm">
+        <Card.Body className="d-flex flex-column gap-3">
+          <div>
+            <Card.Title as="h6" className="mb-1">Sesiones por Centro de Coste</Card.Title>
+            <div className="text-muted small">Cantidad de sesiones agrupadas por centro de coste</div>
+          </div>
+
+          <div className="table-responsive">
+            <table className="table align-middle mb-0">
+              <thead>
+                <tr>
+                  <th className="text-muted small">Centro de coste</th>
+                  <th className="text-muted small text-end">Preventivos</th>
+                  <th className="text-muted small text-end">Formaciones</th>
+                  <th className="text-muted small text-end">Total</th>
+                </tr>
+              </thead>
+              <tbody>
+                {items.length === 0 && (
+                  <tr>
+                    <td colSpan={4} className="text-muted small py-3">
+                      Sin datos para el periodo seleccionado
+                    </td>
+                  </tr>
+                )}
+                {items.map((item) => {
+                  const formaciones = item.formacionEmpresa + item.formacionAbierta;
+                  const total = item.gepServices + formaciones;
+                  return (
+                    <tr key={item.costCenter}>
+                      <td className="small fw-semibold">{item.costCenter}</td>
+                      <td className="text-end">{numberFormatter.format(item.gepServices)}</td>
+                      <td className="text-end">{numberFormatter.format(formaciones)}</td>
+                      <td className="text-end fw-semibold">{numberFormatter.format(total)}</td>
+                    </tr>
+                  );
+                })}
+                {items.length > 0 && (() => {
+                  const totalGep = items.reduce((acc, i) => acc + i.gepServices, 0);
+                  const totalFormaciones = items.reduce((acc, i) => acc + i.formacionEmpresa + i.formacionAbierta, 0);
+                  const grandTotal = totalGep + totalFormaciones;
+                  return (
+                    <tr className="table-light fw-semibold">
+                      <td className="small">Total</td>
+                      <td className="text-end">{numberFormatter.format(totalGep)}</td>
+                      <td className="text-end">{numberFormatter.format(totalFormaciones)}</td>
+                      <td className="text-end">{numberFormatter.format(grandTotal)}</td>
+                    </tr>
+                  );
+                })()}
+              </tbody>
+            </table>
+          </div>
+        </Card.Body>
+      </Card>
+    );
+  };
+
   const renderMobileUnitsUsage = () => {
     const items = dashboardQuery.data?.mobileUnitsUsage ?? [];
 
@@ -995,6 +1064,12 @@ export default function ComparativaDashboardPage() {
               {renderBreakdownCard(item)}
             </Col>
           ))}
+        </Row>
+
+        <Row className="g-3">
+          <Col xs={12}>
+            {renderCostCenterBreakdown()}
+          </Col>
         </Row>
 
         <Row className="g-3">
@@ -1192,6 +1267,15 @@ export default function ComparativaDashboardPage() {
                 options={trainingTypeOptions}
                 selected={filters.trainingTypes ?? []}
                 onChange={(values) => handleMultiSelectorChange('trainingTypes', values)}
+              />
+            </Col>
+
+            <Col xs={12} md={6} lg={2}>
+              <FilterMultiSelect
+                label="Centro de coste"
+                options={costCenterOptions}
+                selected={filters.costCenterIds ?? []}
+                onChange={(values) => handleMultiSelectorChange('costCenterIds', values)}
               />
             </Col>
 


### PR DESCRIPTION
## Resumen

- Nuevo filtro multi-selección **Centro de coste** en el panel de filtros de `/reporting/comparativa`
- Nueva tabla numérica **Sesiones por Centro de Coste** (ubicada antes de la tabla de unidades móviles), con columnas: Centro de coste · Preventivos · Formaciones · Total — incluye fila de totales

## Cambios técnicos

**Backend (`reporting-comparativa.ts`)**
- Parseo del parámetro `costCenter` / `costCenters` / `centro_coste` desde la query
- `centro_coste` añadido al `select` de deals en todas las consultas de sesiones y variant deals
- Filtro `centro_coste: { in: costCenters }` aplicado en los WHERE de sesiones y variant deals
- Cálculo de `costCenterBreakdown`: sesiones del periodo actual agrupadas por centro de coste, subdivididas en `gepServices`, `formacionEmpresa` y `formacionAbierta` (incluye variantes de WooCommerce)
- `filterOptions.costCenters` con los valores distintos de `centro_coste` en la base de datos

**API (`features/reporting/api.ts`)**
- Nuevo tipo `ComparativaCostCenterBreakdown`
- `costCenterIds?: string[]` en `ComparativaFilters`
- `costCenterBreakdown` y `filterOptions.costCenters` en `ComparativaDashboardResponse`
- `fetchComparativaDashboard` pasa `costCenter` al query string

**Frontend (`ComparativaDashboardPage.tsx`)**
- Filtro `FilterMultiSelect` para "Centro de coste" en el panel de filtros
- Badge de filtro aplicado para centro de coste
- `renderCostCenterBreakdown()`: tabla con fila de totales, inserida antes de `renderMobileUnitsUsage()`

https://claude.ai/code/session_01Rq1fDPFZG5PBpUcwUVgAbE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rq1fDPFZG5PBpUcwUVgAbE)_