### PR TITLE
Añade tablas comparativas anuales por centro de coste

### DIFF
--- a/backend/functions/reporting-comparativa.ts
+++ b/backend/functions/reporting-comparativa.ts
@@ -1210,18 +1210,48 @@ export const handler = createHttpHandler(async (request) => {
     ...mobileUnitSessionGroups,
   ];
 
-  const [dealSites, variantSites, pipelineOptions, comercialOptions, costCenterOptions]: [
+  const YEARLY_START = new Date(Date.UTC(2022, 0, 1));
+
+  const [dealSites, variantSites, pipelineOptions, comercialOptions, costCenterOptions, allYearlySessionsRaw, allYearlyVariantDeals]: [
     { sede_label: string | null }[],
     { sede: string | null }[],
     { pipeline_id: string | null }[],
     { comercial: string | null }[],
     { centro_coste: string | null }[],
+    Array<{ fecha_inicio_utc: Date | null; deals: { pipeline_id: string | null; centro_coste: string | null } | null }>,
+    Array<{ a_fecha: Date | null; centro_coste: string | null }>,
   ] = await Promise.all([
     prisma.deals.findMany({ distinct: ['sede_label'], select: { sede_label: true } }),
     prisma.variants.findMany({ distinct: ['sede'], select: { sede: true } }),
     prisma.deals.findMany({ distinct: ['pipeline_id'], select: { pipeline_id: true } }),
     prisma.deals.findMany({ distinct: ['comercial'], select: { comercial: true } }),
     prisma.deals.findMany({ distinct: ['centro_coste'], select: { centro_coste: true } }),
+    prisma.sesiones.findMany({
+      where: {
+        fecha_inicio_utc: { gte: YEARLY_START },
+        deals: {
+          ...(siteFilters ? { sede_label: { in: siteFilters } } : {}),
+          ...(trainingTypes ? { pipeline_id: { in: trainingTypes } } : {}),
+          ...(comerciales ? { comercial: { in: comerciales } } : {}),
+          ...(costCenters ? { centro_coste: { in: costCenters } } : {}),
+        },
+      },
+      select: {
+        fecha_inicio_utc: true,
+        deals: { select: { pipeline_id: true, centro_coste: true } },
+      },
+    }),
+    prisma.deals.findMany({
+      where: {
+        w_id_variation: { not: null },
+        a_fecha: { gte: YEARLY_START },
+        ...(siteFilters ? { sede_label: { in: siteFilters } } : {}),
+        ...(trainingTypes ? { pipeline_id: { in: trainingTypes } } : {}),
+        ...(comerciales ? { comercial: { in: comerciales } } : {}),
+        ...(costCenters ? { centro_coste: { in: costCenters } } : {}),
+      },
+      select: { a_fecha: true, centro_coste: true },
+    }),
   ]);
 
   const siteOptionSet = new Set<string>();
@@ -1249,6 +1279,52 @@ export const handler = createHttpHandler(async (request) => {
       .filter((value): value is string => Boolean(value))
       .sort((a, b) => a.localeCompare(b)),
   } as const;
+
+  type YearlyCostCenterEntry = { year: number; costCenter: string; formaciones: number; preventivos: number };
+  const yearlyMap = new Map<string, YearlyCostCenterEntry>();
+
+  const getYearlyEntry = (year: number, cc: string): YearlyCostCenterEntry => {
+    const key = `${year}:${cc}`;
+    if (!yearlyMap.has(key)) {
+      yearlyMap.set(key, { year, costCenter: cc, formaciones: 0, preventivos: 0 });
+    }
+    return yearlyMap.get(key)!;
+  };
+
+  for (const session of allYearlySessionsRaw) {
+    if (!session.fecha_inicio_utc) continue;
+    const pipeline = normalizePipelineLabel(session.deals?.pipeline_id ?? null);
+    if (!pipeline || isPciPipeline(pipeline)) continue;
+    const year = new Date(session.fecha_inicio_utc).getUTCFullYear();
+    const cc = session.deals?.centro_coste?.trim() || 'Sin centro de coste';
+    const entry = getYearlyEntry(year, cc);
+    if (pipeline === 'gep services' || pipeline === 'preventivos') {
+      entry.preventivos++;
+    } else {
+      entry.formaciones++;
+    }
+  }
+
+  for (const deal of allYearlyVariantDeals) {
+    if (!deal.a_fecha) continue;
+    const year = new Date(deal.a_fecha).getUTCFullYear();
+    const cc = deal.centro_coste?.trim() || 'Sin centro de coste';
+    getYearlyEntry(year, cc).formaciones++;
+  }
+
+  const yearlyEntries = Array.from(yearlyMap.values())
+    .sort((a, b) => a.year - b.year || a.costCenter.localeCompare(b.costCenter));
+
+  const yearlyYears = Array.from(new Set(yearlyEntries.map((e) => e.year))).sort((a, b) => a - b);
+  const yearlyCostCenters = Array.from(new Set(yearlyEntries.map((e) => e.costCenter))).sort((a, b) =>
+    a.localeCompare(b),
+  );
+
+  const costCenterYearlyBreakdown = {
+    years: yearlyYears,
+    costCenters: yearlyCostCenters,
+    entries: yearlyEntries,
+  };
 
   return successResponse({
     highlights,
@@ -1288,6 +1364,7 @@ export const handler = createHttpHandler(async (request) => {
     listingSessions,
     mobileUnitsUsage,
     costCenterBreakdown,
+    costCenterYearlyBreakdown,
     filterOptions,
   });
 });

--- a/frontend/src/features/reporting/api.ts
+++ b/frontend/src/features/reporting/api.ts
@@ -1223,6 +1223,19 @@ export type ComparativaCostCenterBreakdown = {
   formacionAbierta: number;
 };
 
+export type ComparativaCostCenterYearlyEntry = {
+  year: number;
+  costCenter: string;
+  formaciones: number;
+  preventivos: number;
+};
+
+export type ComparativaCostCenterYearlyBreakdown = {
+  years: number[];
+  costCenters: string[];
+  entries: ComparativaCostCenterYearlyEntry[];
+};
+
 export type ComparativaDashboardResponse = {
   highlights: ComparativaKpi[];
   trends: ComparativaTrend[];
@@ -1236,6 +1249,7 @@ export type ComparativaDashboardResponse = {
   listingSessions: ComparativaSessionGroup[];
   mobileUnitsUsage: ComparativaMobileUnitUsage[];
   costCenterBreakdown: ComparativaCostCenterBreakdown[];
+  costCenterYearlyBreakdown: ComparativaCostCenterYearlyBreakdown;
   filterOptions: {
     sites: string[];
     trainingTypes: string[];

--- a/frontend/src/pages/reporting/ComparativaDashboardPage.tsx
+++ b/frontend/src/pages/reporting/ComparativaDashboardPage.tsx
@@ -11,6 +11,7 @@ import {
   type ComparativaTrend,
   type ComparativaSessionGroup,
   type ComparativaCostCenterBreakdown,
+  type ComparativaCostCenterYearlyBreakdown,
 } from '../../features/reporting/api';
 
 const METRIC_CONFIG: { key: string; label: string }[] = [
@@ -943,6 +944,115 @@ export default function ComparativaDashboardPage() {
     );
   };
 
+  const renderCostCenterYearlyTable = (
+    title: string,
+    description: string,
+    getValue: (entry: ComparativaCostCenterYearlyBreakdown['entries'][number]) => number,
+  ) => {
+    const data: ComparativaCostCenterYearlyBreakdown = dashboardQuery.data?.costCenterYearlyBreakdown ?? {
+      years: [],
+      costCenters: [],
+      entries: [],
+    };
+    const { years, costCenters, entries } = data;
+
+    if (years.length === 0 || costCenters.length === 0) {
+      return (
+        <Card className="h-100 shadow-sm">
+          <Card.Body className="d-flex flex-column gap-3">
+            <div>
+              <Card.Title as="h6" className="mb-1">{title}</Card.Title>
+              <div className="text-muted small">{description}</div>
+            </div>
+            <div className="text-muted small py-3">Sin datos disponibles</div>
+          </Card.Body>
+        </Card>
+      );
+    }
+
+    const entryMap = new Map<string, number>();
+    for (const entry of entries) {
+      entryMap.set(`${entry.year}:${entry.costCenter}`, getValue(entry));
+    }
+
+    const getVal = (year: number, cc: string) => entryMap.get(`${year}:${cc}`) ?? 0;
+
+    const rowTotals = years.map((year) =>
+      costCenters.reduce((sum, cc) => sum + getVal(year, cc), 0),
+    );
+
+    const colTotals = costCenters.map((cc) =>
+      years.reduce((sum, year) => sum + getVal(year, cc), 0),
+    );
+
+    const grandTotal = rowTotals.reduce((sum, v) => sum + v, 0);
+
+    const lastYear = years[years.length - 1];
+    const prevYear = years.length >= 2 ? years[years.length - 2] : null;
+
+    const formatPct = (current: number, previous: number) => {
+      if (previous === 0) return current === 0 ? '—' : '+∞%';
+      const pct = ((current - previous) / previous) * 100;
+      return `${pct >= 0 ? '+' : ''}${pct.toFixed(2)}%`;
+    };
+
+    return (
+      <Card className="h-100 shadow-sm">
+        <Card.Body className="d-flex flex-column gap-3">
+          <div>
+            <Card.Title as="h6" className="mb-1">{title}</Card.Title>
+            <div className="text-muted small">{description}</div>
+          </div>
+
+          <div className="table-responsive">
+            <table className="table align-middle mb-0" style={{ fontSize: '0.8rem' }}>
+              <thead>
+                <tr>
+                  <th className="text-muted small" style={{ minWidth: 60 }}></th>
+                  <th className="text-muted small text-end fw-semibold">Total</th>
+                  {costCenters.map((cc) => (
+                    <th key={cc} className="text-muted small text-end" style={{ minWidth: 90 }}>{cc}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {years.map((year, yi) => (
+                  <tr key={year}>
+                    <td className="fw-semibold" style={{ color: '#3b6abf' }}>{year}</td>
+                    <td className="text-end fw-semibold">{numberFormatter.format(rowTotals[yi])}</td>
+                    {costCenters.map((cc) => (
+                      <td key={cc} className="text-end">{numberFormatter.format(getVal(year, cc))}</td>
+                    ))}
+                  </tr>
+                ))}
+                {prevYear !== null && (
+                  <tr className="table-light">
+                    <td className="small text-muted">{prevYear}→{lastYear}</td>
+                    <td className="text-end small">
+                      {formatPct(rowTotals[years.length - 1], rowTotals[years.length - 2])}
+                    </td>
+                    {costCenters.map((cc) => (
+                      <td key={cc} className="text-end small text-muted">
+                        {formatPct(getVal(lastYear, cc), getVal(prevYear, cc))}
+                      </td>
+                    ))}
+                  </tr>
+                )}
+                <tr className="fw-semibold table-secondary">
+                  <td className="small">Total</td>
+                  <td className="text-end">{numberFormatter.format(grandTotal)}</td>
+                  {costCenters.map((cc, ci) => (
+                    <td key={cc} className="text-end">{numberFormatter.format(colTotals[ci])}</td>
+                  ))}
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </Card.Body>
+      </Card>
+    );
+  };
+
   const renderMobileUnitsUsage = () => {
     const items = dashboardQuery.data?.mobileUnitsUsage ?? [];
 
@@ -1069,6 +1179,26 @@ export default function ComparativaDashboardPage() {
         <Row className="g-3">
           <Col xs={12}>
             {renderCostCenterBreakdown()}
+          </Col>
+        </Row>
+
+        <Row className="g-3">
+          <Col xs={12}>
+            {renderCostCenterYearlyTable(
+              'Formaciones por año y centro de coste',
+              'Comparativa anual de formaciones agrupadas por centro de coste',
+              (e) => e.formaciones,
+            )}
+          </Col>
+        </Row>
+
+        <Row className="g-3">
+          <Col xs={12}>
+            {renderCostCenterYearlyTable(
+              'Preventivos por año y centro de coste',
+              'Comparativa anual de preventivos agrupados por centro de coste',
+              (e) => e.preventivos,
+            )}
           </Col>
         </Row>
 


### PR DESCRIPTION
## Resumen

- Se añaden dos nuevas tablas debajo de "Sesiones por Centro de Coste" en el dashboard comparativo
- **Formaciones por año y centro de coste**: filas por año (desde 2022), columnas por cada centro de coste
- **Preventivos por año y centro de coste**: misma estructura pero mostrando preventivos

## Detalle técnico

**Backend** (`reporting-comparativa.ts`):
- Nueva consulta que agrega sesiones desde 2022 por año y centro de coste (respetando los mismos filtros de sede, tipo de formación, comercial y centro de coste)
- También agrega deals de variantes (formación abierta) por `a_fecha` y `centro_coste`
- Se añade `costCenterYearlyBreakdown` al response del dashboard

**Frontend** (`api.ts`):
- Nuevos tipos `ComparativaCostCenterYearlyEntry` y `ComparativaCostCenterYearlyBreakdown`

**Frontend** (`ComparativaDashboardPage.tsx`):
- Función genérica `renderCostCenterYearlyTable` reutilizable para formaciones y preventivos
- Cada tabla muestra: años como filas, centros de coste como columnas, totales por fila/columna y fila de variación % entre los dos últimos años

## Plan de pruebas

- [ ] Verificar que la tabla de formaciones muestra datos por año y centro de coste
- [ ] Verificar que la tabla de preventivos muestra datos por año y centro de coste
- [ ] Comprobar que la fila de % variación es correcta (último año vs penúltimo)
- [ ] Comprobar que los filtros del dashboard (sede, tipo, comercial, centro de coste) afectan a las nuevas tablas
- [ ] Verificar que se muestra "Sin datos disponibles" cuando no hay datos

https://claude.ai/code/session_011PLqqNj6x5h1DviywE5CpS

---
_Generated by [Claude Code](https://claude.ai/code/session_011PLqqNj6x5h1DviywE5CpS)_