### PR TITLE
Tablas comparativas de CC respetan el filtro de fechas del dashboard

### DIFF
--- a/backend/functions/reporting-comparativa.ts
+++ b/backend/functions/reporting-comparativa.ts
@@ -1210,48 +1210,18 @@ export const handler = createHttpHandler(async (request) => {
     ...mobileUnitSessionGroups,
   ];
 
-  const YEARLY_START = new Date(Date.UTC(2022, 0, 1));
-
-  const [dealSites, variantSites, pipelineOptions, comercialOptions, costCenterOptions, allYearlySessionsRaw, allYearlyVariantDeals]: [
+  const [dealSites, variantSites, pipelineOptions, comercialOptions, costCenterOptions]: [
     { sede_label: string | null }[],
     { sede: string | null }[],
     { pipeline_id: string | null }[],
     { comercial: string | null }[],
     { centro_coste: string | null }[],
-    Array<{ fecha_inicio_utc: Date | null; deals: { pipeline_id: string | null; centro_coste: string | null } | null }>,
-    Array<{ a_fecha: Date | null; centro_coste: string | null }>,
   ] = await Promise.all([
     prisma.deals.findMany({ distinct: ['sede_label'], select: { sede_label: true } }),
     prisma.variants.findMany({ distinct: ['sede'], select: { sede: true } }),
     prisma.deals.findMany({ distinct: ['pipeline_id'], select: { pipeline_id: true } }),
     prisma.deals.findMany({ distinct: ['comercial'], select: { comercial: true } }),
     prisma.deals.findMany({ distinct: ['centro_coste'], select: { centro_coste: true } }),
-    prisma.sesiones.findMany({
-      where: {
-        fecha_inicio_utc: { gte: YEARLY_START },
-        deals: {
-          ...(siteFilters ? { sede_label: { in: siteFilters } } : {}),
-          ...(trainingTypes ? { pipeline_id: { in: trainingTypes } } : {}),
-          ...(comerciales ? { comercial: { in: comerciales } } : {}),
-          ...(costCenters ? { centro_coste: { in: costCenters } } : {}),
-        },
-      },
-      select: {
-        fecha_inicio_utc: true,
-        deals: { select: { pipeline_id: true, centro_coste: true } },
-      },
-    }),
-    prisma.deals.findMany({
-      where: {
-        w_id_variation: { not: null },
-        a_fecha: { gte: YEARLY_START },
-        ...(siteFilters ? { sede_label: { in: siteFilters } } : {}),
-        ...(trainingTypes ? { pipeline_id: { in: trainingTypes } } : {}),
-        ...(comerciales ? { comercial: { in: comerciales } } : {}),
-        ...(costCenters ? { centro_coste: { in: costCenters } } : {}),
-      },
-      select: { a_fecha: true, centro_coste: true },
-    }),
   ]);
 
   const siteOptionSet = new Set<string>();
@@ -1280,50 +1250,62 @@ export const handler = createHttpHandler(async (request) => {
       .sort((a, b) => a.localeCompare(b)),
   } as const;
 
-  type YearlyCostCenterEntry = { year: number; costCenter: string; formaciones: number; preventivos: number };
-  const yearlyMap = new Map<string, YearlyCostCenterEntry>();
-
-  const getYearlyEntry = (year: number, cc: string): YearlyCostCenterEntry => {
-    const key = `${year}:${cc}`;
-    if (!yearlyMap.has(key)) {
-      yearlyMap.set(key, { year, costCenter: cc, formaciones: 0, preventivos: 0 });
+  const previousVariantCostCenterById = new Map<string, string>();
+  for (const deal of previousVariantDeals as Array<{ w_id_variation: unknown; centro_coste?: string | null }>) {
+    const normalizedId = normalizeVariantWooId(deal.w_id_variation);
+    if (!normalizedId) continue;
+    if (!previousVariantCostCenterById.has(normalizedId) && deal.centro_coste?.trim()) {
+      previousVariantCostCenterById.set(normalizedId, deal.centro_coste.trim());
     }
-    return yearlyMap.get(key)!;
+  }
+
+  type PeriodCCEntry = { costCenter: string; formaciones: number; preventivos: number };
+
+  const buildPeriodCCMap = (
+    sessions: typeof currentSessions,
+    variants: typeof filteredCurrentVariants,
+    ccById: Map<string, string>,
+  ): Map<string, PeriodCCEntry> => {
+    const map = new Map<string, PeriodCCEntry>();
+    const get = (cc: string): PeriodCCEntry => {
+      if (!map.has(cc)) map.set(cc, { costCenter: cc, formaciones: 0, preventivos: 0 });
+      return map.get(cc)!;
+    };
+    for (const session of sessions) {
+      const classif = classifySession(session);
+      if (!classif) continue;
+      const cc = session.deals?.centro_coste?.trim() || 'Sin centro de coste';
+      if (classif === 'gepServices') get(cc).preventivos++;
+      else get(cc).formaciones++;
+    }
+    for (const variant of variants) {
+      const normalizedId = normalizeVariantWooId(variant.id_woo);
+      const cc = (normalizedId ? ccById.get(normalizedId) : null) ?? 'Sin centro de coste';
+      get(cc).formaciones++;
+    }
+    return map;
   };
 
-  for (const session of allYearlySessionsRaw) {
-    if (!session.fecha_inicio_utc) continue;
-    const pipeline = normalizePipelineLabel(session.deals?.pipeline_id ?? null);
-    if (!pipeline || isPciPipeline(pipeline)) continue;
-    const year = new Date(session.fecha_inicio_utc).getUTCFullYear();
-    const cc = session.deals?.centro_coste?.trim() || 'Sin centro de coste';
-    const entry = getYearlyEntry(year, cc);
-    if (pipeline === 'gep services' || pipeline === 'preventivos') {
-      entry.preventivos++;
-    } else {
-      entry.formaciones++;
-    }
-  }
+  const currentCCMap = buildPeriodCCMap(currentSessions, filteredCurrentVariants, currentVariantCostCenterById);
+  const previousCCMap = buildPeriodCCMap(previousSessions, filteredPreviousVariants, previousVariantCostCenterById);
 
-  for (const deal of allYearlyVariantDeals) {
-    if (!deal.a_fecha) continue;
-    const year = new Date(deal.a_fecha).getUTCFullYear();
-    const cc = deal.centro_coste?.trim() || 'Sin centro de coste';
-    getYearlyEntry(year, cc).formaciones++;
-  }
+  const comparativeCostCenters = Array.from(
+    new Set([...currentCCMap.keys(), ...previousCCMap.keys()]),
+  ).sort((a, b) => a.localeCompare(b));
 
-  const yearlyEntries = Array.from(yearlyMap.values())
-    .sort((a, b) => a.year - b.year || a.costCenter.localeCompare(b.costCenter));
-
-  const yearlyYears = Array.from(new Set(yearlyEntries.map((e) => e.year))).sort((a, b) => a - b);
-  const yearlyCostCenters = Array.from(new Set(yearlyEntries.map((e) => e.costCenter))).sort((a, b) =>
-    a.localeCompare(b),
-  );
+  const currentLabel = String(currentStart.getUTCFullYear());
+  const previousLabel = String(previousStart.getUTCFullYear());
 
   const costCenterYearlyBreakdown = {
-    years: yearlyYears,
-    costCenters: yearlyCostCenters,
-    entries: yearlyEntries,
+    currentLabel,
+    previousLabel,
+    costCenters: comparativeCostCenters,
+    currentEntries: comparativeCostCenters.map(
+      (cc) => currentCCMap.get(cc) ?? { costCenter: cc, formaciones: 0, preventivos: 0 },
+    ),
+    previousEntries: comparativeCostCenters.map(
+      (cc) => previousCCMap.get(cc) ?? { costCenter: cc, formaciones: 0, preventivos: 0 },
+    ),
   };
 
   return successResponse({

--- a/backend/functions/reporting-comparativa.ts
+++ b/backend/functions/reporting-comparativa.ts
@@ -1210,18 +1210,48 @@ export const handler = createHttpHandler(async (request) => {
     ...mobileUnitSessionGroups,
   ];
 
-  const [dealSites, variantSites, pipelineOptions, comercialOptions, costCenterOptions]: [
+  const YEARLY_START = new Date(Date.UTC(2022, 0, 1));
+
+  const [dealSites, variantSites, pipelineOptions, comercialOptions, costCenterOptions, allYearlySessionsRaw, allYearlyVariantDeals]: [
     { sede_label: string | null }[],
     { sede: string | null }[],
     { pipeline_id: string | null }[],
     { comercial: string | null }[],
     { centro_coste: string | null }[],
+    Array<{ fecha_inicio_utc: Date | null; deals: { pipeline_id: string | null; centro_coste: string | null } | null }>,
+    Array<{ a_fecha: Date | null; centro_coste: string | null }>,
   ] = await Promise.all([
     prisma.deals.findMany({ distinct: ['sede_label'], select: { sede_label: true } }),
     prisma.variants.findMany({ distinct: ['sede'], select: { sede: true } }),
     prisma.deals.findMany({ distinct: ['pipeline_id'], select: { pipeline_id: true } }),
     prisma.deals.findMany({ distinct: ['comercial'], select: { comercial: true } }),
     prisma.deals.findMany({ distinct: ['centro_coste'], select: { centro_coste: true } }),
+    prisma.sesiones.findMany({
+      where: {
+        fecha_inicio_utc: { gte: YEARLY_START },
+        deals: {
+          ...(siteFilters ? { sede_label: { in: siteFilters } } : {}),
+          ...(trainingTypes ? { pipeline_id: { in: trainingTypes } } : {}),
+          ...(comerciales ? { comercial: { in: comerciales } } : {}),
+          ...(costCenters ? { centro_coste: { in: costCenters } } : {}),
+        },
+      },
+      select: {
+        fecha_inicio_utc: true,
+        deals: { select: { pipeline_id: true, centro_coste: true } },
+      },
+    }),
+    prisma.deals.findMany({
+      where: {
+        w_id_variation: { not: null },
+        a_fecha: { gte: YEARLY_START },
+        ...(siteFilters ? { sede_label: { in: siteFilters } } : {}),
+        ...(trainingTypes ? { pipeline_id: { in: trainingTypes } } : {}),
+        ...(comerciales ? { comercial: { in: comerciales } } : {}),
+        ...(costCenters ? { centro_coste: { in: costCenters } } : {}),
+      },
+      select: { a_fecha: true, centro_coste: true },
+    }),
   ]);
 
   const siteOptionSet = new Set<string>();
@@ -1249,6 +1279,52 @@ export const handler = createHttpHandler(async (request) => {
       .filter((value): value is string => Boolean(value))
       .sort((a, b) => a.localeCompare(b)),
   } as const;
+
+  type YearlyCostCenterEntry = { year: number; costCenter: string; formaciones: number; preventivos: number };
+  const yearlyMap = new Map<string, YearlyCostCenterEntry>();
+
+  const getYearlyEntry = (year: number, cc: string): YearlyCostCenterEntry => {
+    const key = `${year}:${cc}`;
+    if (!yearlyMap.has(key)) {
+      yearlyMap.set(key, { year, costCenter: cc, formaciones: 0, preventivos: 0 });
+    }
+    return yearlyMap.get(key)!;
+  };
+
+  for (const session of allYearlySessionsRaw) {
+    if (!session.fecha_inicio_utc) continue;
+    const pipeline = normalizePipelineLabel(session.deals?.pipeline_id ?? null);
+    if (!pipeline || isPciPipeline(pipeline)) continue;
+    const year = new Date(session.fecha_inicio_utc).getUTCFullYear();
+    const cc = session.deals?.centro_coste?.trim() || 'Sin centro de coste';
+    const entry = getYearlyEntry(year, cc);
+    if (pipeline === 'gep services' || pipeline === 'preventivos') {
+      entry.preventivos++;
+    } else {
+      entry.formaciones++;
+    }
+  }
+
+  for (const deal of allYearlyVariantDeals) {
+    if (!deal.a_fecha) continue;
+    const year = new Date(deal.a_fecha).getUTCFullYear();
+    const cc = deal.centro_coste?.trim() || 'Sin centro de coste';
+    getYearlyEntry(year, cc).formaciones++;
+  }
+
+  const yearlyEntries = Array.from(yearlyMap.values())
+    .sort((a, b) => a.year - b.year || a.costCenter.localeCompare(b.costCenter));
+
+  const yearlyYears = Array.from(new Set(yearlyEntries.map((e) => e.year))).sort((a, b) => a - b);
+  const yearlyCostCenters = Array.from(new Set(yearlyEntries.map((e) => e.costCenter))).sort((a, b) =>
+    a.localeCompare(b),
+  );
+
+  const costCenterYearlyBreakdown = {
+    years: yearlyYears,
+    costCenters: yearlyCostCenters,
+    entries: yearlyEntries,
+  };
 
   return successResponse({
     highlights,
@@ -1288,6 +1364,7 @@ export const handler = createHttpHandler(async (request) => {
     listingSessions,
     mobileUnitsUsage,
     costCenterBreakdown,
+    costCenterYearlyBreakdown,
     filterOptions,
   });
 });

--- a/frontend/src/features/reporting/api.ts
+++ b/frontend/src/features/reporting/api.ts
@@ -1223,17 +1223,18 @@ export type ComparativaCostCenterBreakdown = {
   formacionAbierta: number;
 };
 
-export type ComparativaCostCenterYearlyEntry = {
-  year: number;
+export type ComparativaCostCenterPeriodEntry = {
   costCenter: string;
   formaciones: number;
   preventivos: number;
 };
 
 export type ComparativaCostCenterYearlyBreakdown = {
-  years: number[];
+  currentLabel: string;
+  previousLabel: string;
   costCenters: string[];
-  entries: ComparativaCostCenterYearlyEntry[];
+  currentEntries: ComparativaCostCenterPeriodEntry[];
+  previousEntries: ComparativaCostCenterPeriodEntry[];
 };
 
 export type ComparativaDashboardResponse = {

--- a/frontend/src/features/reporting/api.ts
+++ b/frontend/src/features/reporting/api.ts
@@ -1223,6 +1223,19 @@ export type ComparativaCostCenterBreakdown = {
   formacionAbierta: number;
 };
 
+export type ComparativaCostCenterYearlyEntry = {
+  year: number;
+  costCenter: string;
+  formaciones: number;
+  preventivos: number;
+};
+
+export type ComparativaCostCenterYearlyBreakdown = {
+  years: number[];
+  costCenters: string[];
+  entries: ComparativaCostCenterYearlyEntry[];
+};
+
 export type ComparativaDashboardResponse = {
   highlights: ComparativaKpi[];
   trends: ComparativaTrend[];
@@ -1236,6 +1249,7 @@ export type ComparativaDashboardResponse = {
   listingSessions: ComparativaSessionGroup[];
   mobileUnitsUsage: ComparativaMobileUnitUsage[];
   costCenterBreakdown: ComparativaCostCenterBreakdown[];
+  costCenterYearlyBreakdown: ComparativaCostCenterYearlyBreakdown;
   filterOptions: {
     sites: string[];
     trainingTypes: string[];

--- a/frontend/src/pages/reporting/ComparativaDashboardPage.tsx
+++ b/frontend/src/pages/reporting/ComparativaDashboardPage.tsx
@@ -12,6 +12,7 @@ import {
   type ComparativaSessionGroup,
   type ComparativaCostCenterBreakdown,
   type ComparativaCostCenterYearlyBreakdown,
+  type ComparativaCostCenterPeriodEntry,
 } from '../../features/reporting/api';
 
 const METRIC_CONFIG: { key: string; label: string }[] = [
@@ -947,16 +948,18 @@ export default function ComparativaDashboardPage() {
   const renderCostCenterYearlyTable = (
     title: string,
     description: string,
-    getValue: (entry: ComparativaCostCenterYearlyBreakdown['entries'][number]) => number,
+    getValue: (entry: ComparativaCostCenterPeriodEntry) => number,
   ) => {
     const data: ComparativaCostCenterYearlyBreakdown = dashboardQuery.data?.costCenterYearlyBreakdown ?? {
-      years: [],
+      currentLabel: '',
+      previousLabel: '',
       costCenters: [],
-      entries: [],
+      currentEntries: [],
+      previousEntries: [],
     };
-    const { years, costCenters, entries } = data;
+    const { currentLabel, previousLabel, costCenters, currentEntries, previousEntries } = data;
 
-    if (years.length === 0 || costCenters.length === 0) {
+    if (costCenters.length === 0) {
       return (
         <Card className="h-100 shadow-sm">
           <Card.Body className="d-flex flex-column gap-3">
@@ -964,31 +967,20 @@ export default function ComparativaDashboardPage() {
               <Card.Title as="h6" className="mb-1">{title}</Card.Title>
               <div className="text-muted small">{description}</div>
             </div>
-            <div className="text-muted small py-3">Sin datos disponibles</div>
+            <div className="text-muted small py-3">Sin datos para el periodo seleccionado</div>
           </Card.Body>
         </Card>
       );
     }
 
-    const entryMap = new Map<string, number>();
-    for (const entry of entries) {
-      entryMap.set(`${entry.year}:${entry.costCenter}`, getValue(entry));
-    }
+    const currentValues = currentEntries.map(getValue);
+    const previousValues = previousEntries.map(getValue);
 
-    const getVal = (year: number, cc: string) => entryMap.get(`${year}:${cc}`) ?? 0;
+    const currentTotal = currentValues.reduce((s, v) => s + v, 0);
+    const previousTotal = previousValues.reduce((s, v) => s + v, 0);
 
-    const rowTotals = years.map((year) =>
-      costCenters.reduce((sum, cc) => sum + getVal(year, cc), 0),
-    );
-
-    const colTotals = costCenters.map((cc) =>
-      years.reduce((sum, year) => sum + getVal(year, cc), 0),
-    );
-
-    const grandTotal = rowTotals.reduce((sum, v) => sum + v, 0);
-
-    const lastYear = years[years.length - 1];
-    const prevYear = years.length >= 2 ? years[years.length - 2] : null;
+    const colTotals = costCenters.map((_, i) => currentValues[i] + previousValues[i]);
+    const grandTotal = currentTotal + previousTotal;
 
     const formatPct = (current: number, previous: number) => {
       if (previous === 0) return current === 0 ? '—' : '+∞%';
@@ -1016,33 +1008,34 @@ export default function ComparativaDashboardPage() {
                 </tr>
               </thead>
               <tbody>
-                {years.map((year, yi) => (
-                  <tr key={year}>
-                    <td className="fw-semibold" style={{ color: '#3b6abf' }}>{year}</td>
-                    <td className="text-end fw-semibold">{numberFormatter.format(rowTotals[yi])}</td>
-                    {costCenters.map((cc) => (
-                      <td key={cc} className="text-end">{numberFormatter.format(getVal(year, cc))}</td>
-                    ))}
-                  </tr>
-                ))}
-                {prevYear !== null && (
-                  <tr className="table-light">
-                    <td className="small text-muted">{prevYear}→{lastYear}</td>
-                    <td className="text-end small">
-                      {formatPct(rowTotals[years.length - 1], rowTotals[years.length - 2])}
+                <tr>
+                  <td className="fw-semibold" style={{ color: '#3b6abf' }}>{currentLabel}</td>
+                  <td className="text-end fw-semibold">{numberFormatter.format(currentTotal)}</td>
+                  {currentValues.map((v, i) => (
+                    <td key={costCenters[i]} className="text-end">{numberFormatter.format(v)}</td>
+                  ))}
+                </tr>
+                <tr>
+                  <td className="fw-semibold" style={{ color: '#3b6abf' }}>{previousLabel}</td>
+                  <td className="text-end fw-semibold">{numberFormatter.format(previousTotal)}</td>
+                  {previousValues.map((v, i) => (
+                    <td key={costCenters[i]} className="text-end">{numberFormatter.format(v)}</td>
+                  ))}
+                </tr>
+                <tr className="table-light">
+                  <td className="small text-muted">{previousLabel}→{currentLabel}</td>
+                  <td className="text-end small">{formatPct(currentTotal, previousTotal)}</td>
+                  {costCenters.map((cc, i) => (
+                    <td key={cc} className="text-end small text-muted">
+                      {formatPct(currentValues[i], previousValues[i])}
                     </td>
-                    {costCenters.map((cc) => (
-                      <td key={cc} className="text-end small text-muted">
-                        {formatPct(getVal(lastYear, cc), getVal(prevYear, cc))}
-                      </td>
-                    ))}
-                  </tr>
-                )}
+                  ))}
+                </tr>
                 <tr className="fw-semibold table-secondary">
                   <td className="small">Total</td>
                   <td className="text-end">{numberFormatter.format(grandTotal)}</td>
-                  {costCenters.map((cc, ci) => (
-                    <td key={cc} className="text-end">{numberFormatter.format(colTotals[ci])}</td>
+                  {colTotals.map((v, i) => (
+                    <td key={costCenters[i]} className="text-end">{numberFormatter.format(v)}</td>
                   ))}
                 </tr>
               </tbody>

--- a/frontend/src/pages/reporting/ComparativaDashboardPage.tsx
+++ b/frontend/src/pages/reporting/ComparativaDashboardPage.tsx
@@ -11,6 +11,7 @@ import {
   type ComparativaTrend,
   type ComparativaSessionGroup,
   type ComparativaCostCenterBreakdown,
+  type ComparativaCostCenterYearlyBreakdown,
 } from '../../features/reporting/api';
 
 const METRIC_CONFIG: { key: string; label: string }[] = [
@@ -943,6 +944,115 @@ export default function ComparativaDashboardPage() {
     );
   };
 
+  const renderCostCenterYearlyTable = (
+    title: string,
+    description: string,
+    getValue: (entry: ComparativaCostCenterYearlyBreakdown['entries'][number]) => number,
+  ) => {
+    const data: ComparativaCostCenterYearlyBreakdown = dashboardQuery.data?.costCenterYearlyBreakdown ?? {
+      years: [],
+      costCenters: [],
+      entries: [],
+    };
+    const { years, costCenters, entries } = data;
+
+    if (years.length === 0 || costCenters.length === 0) {
+      return (
+        <Card className="h-100 shadow-sm">
+          <Card.Body className="d-flex flex-column gap-3">
+            <div>
+              <Card.Title as="h6" className="mb-1">{title}</Card.Title>
+              <div className="text-muted small">{description}</div>
+            </div>
+            <div className="text-muted small py-3">Sin datos disponibles</div>
+          </Card.Body>
+        </Card>
+      );
+    }
+
+    const entryMap = new Map<string, number>();
+    for (const entry of entries) {
+      entryMap.set(`${entry.year}:${entry.costCenter}`, getValue(entry));
+    }
+
+    const getVal = (year: number, cc: string) => entryMap.get(`${year}:${cc}`) ?? 0;
+
+    const rowTotals = years.map((year) =>
+      costCenters.reduce((sum, cc) => sum + getVal(year, cc), 0),
+    );
+
+    const colTotals = costCenters.map((cc) =>
+      years.reduce((sum, year) => sum + getVal(year, cc), 0),
+    );
+
+    const grandTotal = rowTotals.reduce((sum, v) => sum + v, 0);
+
+    const lastYear = years[years.length - 1];
+    const prevYear = years.length >= 2 ? years[years.length - 2] : null;
+
+    const formatPct = (current: number, previous: number) => {
+      if (previous === 0) return current === 0 ? '—' : '+∞%';
+      const pct = ((current - previous) / previous) * 100;
+      return `${pct >= 0 ? '+' : ''}${pct.toFixed(2)}%`;
+    };
+
+    return (
+      <Card className="h-100 shadow-sm">
+        <Card.Body className="d-flex flex-column gap-3">
+          <div>
+            <Card.Title as="h6" className="mb-1">{title}</Card.Title>
+            <div className="text-muted small">{description}</div>
+          </div>
+
+          <div className="table-responsive">
+            <table className="table align-middle mb-0" style={{ fontSize: '0.8rem' }}>
+              <thead>
+                <tr>
+                  <th className="text-muted small" style={{ minWidth: 60 }}></th>
+                  <th className="text-muted small text-end fw-semibold">Total</th>
+                  {costCenters.map((cc) => (
+                    <th key={cc} className="text-muted small text-end" style={{ minWidth: 90 }}>{cc}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {years.map((year, yi) => (
+                  <tr key={year}>
+                    <td className="fw-semibold" style={{ color: '#3b6abf' }}>{year}</td>
+                    <td className="text-end fw-semibold">{numberFormatter.format(rowTotals[yi])}</td>
+                    {costCenters.map((cc) => (
+                      <td key={cc} className="text-end">{numberFormatter.format(getVal(year, cc))}</td>
+                    ))}
+                  </tr>
+                ))}
+                {prevYear !== null && (
+                  <tr className="table-light">
+                    <td className="small text-muted">{prevYear}→{lastYear}</td>
+                    <td className="text-end small">
+                      {formatPct(rowTotals[years.length - 1], rowTotals[years.length - 2])}
+                    </td>
+                    {costCenters.map((cc) => (
+                      <td key={cc} className="text-end small text-muted">
+                        {formatPct(getVal(lastYear, cc), getVal(prevYear, cc))}
+                      </td>
+                    ))}
+                  </tr>
+                )}
+                <tr className="fw-semibold table-secondary">
+                  <td className="small">Total</td>
+                  <td className="text-end">{numberFormatter.format(grandTotal)}</td>
+                  {costCenters.map((cc, ci) => (
+                    <td key={cc} className="text-end">{numberFormatter.format(colTotals[ci])}</td>
+                  ))}
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </Card.Body>
+      </Card>
+    );
+  };
+
   const renderMobileUnitsUsage = () => {
     const items = dashboardQuery.data?.mobileUnitsUsage ?? [];
 
@@ -1069,6 +1179,26 @@ export default function ComparativaDashboardPage() {
         <Row className="g-3">
           <Col xs={12}>
             {renderCostCenterBreakdown()}
+          </Col>
+        </Row>
+
+        <Row className="g-3">
+          <Col xs={12}>
+            {renderCostCenterYearlyTable(
+              'Formaciones por año y centro de coste',
+              'Comparativa anual de formaciones agrupadas por centro de coste',
+              (e) => e.formaciones,
+            )}
+          </Col>
+        </Row>
+
+        <Row className="g-3">
+          <Col xs={12}>
+            {renderCostCenterYearlyTable(
+              'Preventivos por año y centro de coste',
+              'Comparativa anual de preventivos agrupados por centro de coste',
+              (e) => e.preventivos,
+            )}
           </Col>
         </Row>
 


### PR DESCRIPTION
## Resumen

- Las tablas "Formaciones por año y centro de coste" y "Preventivos por año y centro de coste" ahora muestran exactamente los datos de los periodos configurados en el filtro del dashboard
- Si el filtro es 01/01/2026–31/05/2026 vs 01/01/2025–31/05/2025 → se muestran 2 filas: **2026** (periodo actual) y **2025** (comparativa)
- Solo aparecen centros de coste que tengan datos en alguno de los dos periodos

## Cambio de comportamiento

**Antes:** se hacían consultas extra a BD desde 2022 independientes del filtro de fechas → mostraba todos los años con datos.  
**Ahora:** se reutilizan los datos ya cargados (`currentSessions` / `previousSessions`) → respeta exactamente el filtro seleccionado.

## Detalle técnico

**Backend** (`reporting-comparativa.ts`):
- Elimina las consultas `YEARLY_START` (ahorro de 2 queries a BD por request)
- Añade `previousVariantCostCenterById` para mapear variantes de formación abierta en el periodo previo
- Calcula `costCenterYearlyBreakdown` desde los arrays ya cargados; labels = año del `startDate` de cada periodo
- Nuevo shape: `{ currentLabel, previousLabel, costCenters, currentEntries, previousEntries }`

**Frontend** (`api.ts` + `ComparativaDashboardPage.tsx`):
- Tipo `ComparativaCostCenterYearlyBreakdown` actualizado con el nuevo shape
- `renderCostCenterYearlyTable` muestra 2 filas de datos + fila de % variación + fila de total acumulado

## Plan de pruebas

- [ ] Seleccionar "Año actual" (2026 vs 2025) → tabla muestra fila 2026 y fila 2025
- [ ] Seleccionar "Mes actual" (mayo 2026 vs mayo 2025) → mismas etiquetas de año, datos parciales
- [ ] Seleccionar "Semana actual" → solo datos de esa semana
- [ ] Aplicar filtro de centro de coste → tabla se acota a ese centro
- [ ] Verificar que la fila % variación es correcta

https://claude.ai/code/session_011PLqqNj6x5h1DviywE5CpS

---
_Generated by [Claude Code](https://claude.ai/code/session_011PLqqNj6x5h1DviywE5CpS)_